### PR TITLE
Mark unexpected conversions as explicit

### DIFF
--- a/e-antic/renfxx.h
+++ b/e-antic/renfxx.h
@@ -99,7 +99,7 @@ public:
     // constructors and destructor
     renf_elem_class();
     ~renf_elem_class();
-    renf_elem_class(renf_class& k);
+    explicit renf_elem_class(renf_class& k);
     renf_elem_class(const renf_elem_class& x);
 
     inline renf_elem_class& operator = (const renf_elem_class& x)
@@ -138,7 +138,7 @@ public:
     __RENFXX_construct(unsigned long int, assign_ui);
     __RENFXX_construct(mpz_class&, assign_mpz_class);
     __RENFXX_construct(mpq_class&, assign_mpq_class);
-    __RENFXX_construct(std::string&, assign_string);
+    explicit __RENFXX_construct(std::string&, assign_string);
     #undef __constructor
 
     // underlying number field


### PR DESCRIPTION
so no implicit conversion happens from a field to the zero element in
that field. And similarly, no explicit conversion should be inteded from
a string as that is more likely a mistake.