### PR TITLE
Remove renf_class constructor

### DIFF
--- a/e-antic/renfxx.h
+++ b/e-antic/renfxx.h
@@ -61,8 +61,6 @@ public:
     // stored embedding) even though they are morally const.
     ::renf_t & renf_t() const noexcept { return nf; }
 
-    [[deprecated("Use the constructor taking std::string instead.")]] renf_class(
-        const char * minpoly, const char * gen, const char * emb, const slong prec);
     [[deprecated("Use renf_t() instead.")]] renf * get_renf() noexcept { return nf; }
     [[deprecated("Use set_pword() instead.")]] std::istream & set_istream(std::istream &) noexcept;
 

--- a/renfxx/renf_class.cpp
+++ b/renfxx/renf_class.cpp
@@ -124,11 +124,6 @@ std::istream & renf_class::set_pword(std::istream & is) noexcept
     return is;
 }
 
-renf_class::renf_class(const char * minpoly, const char * gen, const char * emb, const slong prec)
-    : renf_class(std::string(minpoly), std::string(gen), std::string(emb), prec)
-{
-}
-
 std::istream & renf_class::set_istream(std::istream & is) noexcept { return set_pword(is); }
 
 std::ostream & operator<<(std::ostream & os, const renf_elem_class & a)


### PR DESCRIPTION
char* are implicitly converted to std::string so there should be no
reason to keep this one around. (And now it prints deprecation warnings
if you do something like renf_class("…", "…", "…");)