### PR TITLE
WIP: Backport to C++14

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -38,7 +38,7 @@ Multithread support
 
 Breaking Changes to the C++ Interface
 -------------------------------------
-- `e-antic/renfxx.h` requires C++17.
+- `e-antic/renfxx.h` requires C++14.
 - All classes are now declared in the namespace `eantic`.
 - The semantics of `operator =` have changed. In e-antic 0.1 the following
   would create the unit in the field K.

--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ AC_CHECK_HEADERS(arb.h arf.h, , [AC_MSG_ERROR([arb header not found])])
 AC_SEARCH_LIBS(arb_init, [arb flint-arb],[], [AC_MSG_ERROR([libarb not found])], [-lmpfr])
 
 AC_LANG_PUSH([C++])
-AX_CXX_COMPILE_STDCXX(17)
+AX_CXX_COMPILE_STDCXX(11)
 AC_CHECK_HEADER(gmpxx.h, , [AC_MSG_ERROR([gmpxx header not found (gmp needs to be compiled with c++ support (--enable-cxx))])])
 AC_CHECK_HEADERS(boost/lexical_cast.hpp, , [AC_MSG_ERROR([boost headers not found])])
 AC_LANG_POP([C++])

--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ AC_CHECK_HEADERS(arb.h arf.h, , [AC_MSG_ERROR([arb header not found])])
 AC_SEARCH_LIBS(arb_init, [arb flint-arb],[], [AC_MSG_ERROR([libarb not found])], [-lmpfr])
 
 AC_LANG_PUSH([C++])
-AX_CXX_COMPILE_STDCXX(11)
+AX_CXX_COMPILE_STDCXX(14)
 AC_CHECK_HEADER(gmpxx.h, , [AC_MSG_ERROR([gmpxx header not found (gmp needs to be compiled with c++ support (--enable-cxx))])])
 AC_CHECK_HEADERS(boost/lexical_cast.hpp, , [AC_MSG_ERROR([boost headers not found])])
 AC_LANG_POP([C++])


### PR DESCRIPTION
It should be possible to backport all the C++17 features to C++14 with boost::hana.

Backporting this to C++11 seems really hard. Basically, it would result in having to turn every `if constexpr` into a template specialization. This hurts maintenance and compile time. Also, I'd get horribly cryptic template code. It would probably be better to just unroll the `Integer` stuff completely with macros if we really want C++11. However, it's unclear why we would want that just to roll it back eventually. It would be conceivable to make the header C++11 but require C++14 in the implementation files…

So, sorry for upgrading to C++14 or later here. But since even GCC had C++14 for several years now and we need the latest versions of arb/flint, it seems reasonable to also require a somewhat recent compiler for this.

The result from talking to normaliz was basically that it's not worth to do this right now. They want to get another release out first and then they'll upgrade. They might go to a more recent C++ version then so this might become a non-issue.