### PR TITLE
render installed headers systemwide

### DIFF
--- a/e-antic/nf.h
+++ b/e-antic/nf.h
@@ -32,11 +32,11 @@
 #define NF_INLINE static __inline__
 #endif
 
-#include "gmp.h"
-#include "flint/flint.h"
-#include "flint/fmpz.h"
-#include "flint/fmpz_poly.h"
-#include "flint/fmpq_poly.h"
+#include <gmp.h>
+#include <flint/flint.h>
+#include <flint/fmpz.h>
+#include <flint/fmpz_poly.h>
+#include <flint/fmpq_poly.h>
 
 #ifdef __cplusplus
  extern "C" {

--- a/e-antic/nf_elem.h
+++ b/e-antic/nf_elem.h
@@ -32,14 +32,14 @@
 #define NF_ELEM_INLINE static __inline__
 #endif
 
-#include "gmp.h"
-#include "flint/flint.h"
-#include "flint/fmpq_poly.h"
-#include "flint/fmpq_mat.h"
-#include "flint/fmpz_mat.h"
-#include "flint/fmpz_mod_poly.h"
-#include "e-antic/poly_extra.h"
-#include "e-antic/nf.h"
+#include <gmp.h>
+#include <flint/flint.h>
+#include <flint/fmpq_poly.h>
+#include <flint/fmpq_mat.h>
+#include <flint/fmpz_mat.h>
+#include <flint/fmpz_mod_poly.h>
+#include <e-antic/poly_extra.h>
+#include <e-antic/nf.h>
 
 #ifdef __cplusplus
  extern "C" {


### PR DESCRIPTION
Description: upstream: headers: reformat
 Remove end-of-lines and space-at-begin-of-lines in view to parse
 the headers to extract easily a version maps.
Origin: vendor, Debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2019-05-17