### PR TITLE
Add type_traits for is_integral_v

### DIFF
--- a/e-antic/renfxx.h
+++ b/e-antic/renfxx.h
@@ -15,6 +15,7 @@
 #define RENFXX_H
 
 #include <vector>
+#include <type_traits>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/numeric/conversion/cast.hpp>


### PR DESCRIPTION
without this, there is no compile error (apparently is_integral is
forward declared somewhere) but one can create an unfortunate list of
includes and then get errors such as: `is_integral<int> has no member
value`, i.e., is_integral claims that int is not an integer.