### PR TITLE
d should be positive in renf_init_nth_root_fmpq

### DIFF
--- a/renf/init_nth_root.c
+++ b/renf/init_nth_root.c
@@ -18,6 +18,9 @@ void renf_init_nth_root_fmpq(renf_t nf, fmpq_t d, ulong n, slong prec)
     fmpq_poly_t pol;
     arb_t emb;
 
+    if (fmpz_cmp_si(fmpq_numref(d), 0) < 0)
+        abort();
+
     fmpq_poly_init(pol);
     fmpq_init(p0);
     fmpq_set(p0, d);

--- a/renf/test/t-init_nth_root_fmpq.c
+++ b/renf/test/t-init_nth_root_fmpq.c
@@ -31,6 +31,8 @@ int main()
         fmpq_init(d);
         fmpq_poly_init(p);
         fmpq_set_si(d, n_randtest_not_zero(state), 37);
+        if (fmpq_cmp_si(d, 0) < 0)
+            fmpq_neg(d, d);
         renf_init_nth_root_fmpq(nf, d, 5, 64);
 
         renf_elem_init(a, nf);


### PR DESCRIPTION
Should fix the remaining issue in #61 