### PR TITLE
Pass renf_class by shared_ptr

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,1 +1,1 @@
-Initial version
+NEWS

--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,9 @@ Breaking Changes to the C++ Interface
   renf_elem_class x(K);
   x = renf_elem_class(K, 1);
   ```
+- `renf_class` is now hidden behind a factory to get shared_ptr semantics
+  everywhere. Create a `renf_class` by calling `renf_class::make(…)`. This
+	returns a smart pointer, so you might have to replace some `.` with `->`.
 - The change of semantics in assignment also affects reading from streams (in
   order to create `renf_elem_class`). Before the following would parse an element
   into a number field:

--- a/e-antic/renfxx.h
+++ b/e-antic/renfxx.h
@@ -16,6 +16,7 @@
 
 #include <vector>
 #include <type_traits>
+#include <memory>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/numeric/conversion/cast.hpp>
@@ -30,13 +31,17 @@ namespace eantic {
 
 // A Real Embedded Number Field
 // This class provides C++ memory management for the underlying renf_t.
-class renf_class : boost::equality_comparable<renf_class> {
-public:
+class renf_class : public std::enable_shared_from_this<renf_class>, boost::equality_comparable<renf_class> {
     // The trivial number field adjoining a root of (x - 1) to the rationals
     renf_class() noexcept;
-    renf_class(const renf_class &) noexcept;
-    renf_class(const ::renf_t, const std::string & gen = "a") noexcept;
-    renf_class(const std::string & minpoly, const std::string & gen, const std::string emb, const slong prec = 64);
+    renf_class(const ::renf_t, const std::string &) noexcept;
+    renf_class(const std::string &, const std::string &, const std::string &, const slong);
+
+public:
+    // The trivial number field adjoining a root of (x - 1) to the rationals
+    static std::shared_ptr<const renf_class> make() noexcept;
+    static std::shared_ptr<const renf_class> make(const ::renf_t, const std::string & gen = "a") noexcept;
+    static std::shared_ptr<const renf_class> make(const std::string & minpoly, const std::string & gen, const std::string &emb, const slong prec = 64);
 
     ~renf_class() noexcept;
 
@@ -55,7 +60,7 @@ public:
 
     // Prepare an input stream to read elements living in this number field
     // from it.
-    std::istream & set_pword(std::istream &) noexcept;
+    std::istream & set_pword(std::istream &) const noexcept;
 
     std::string to_string() const noexcept;
     friend std::ostream & operator<<(std::ostream &, const renf_class &);
@@ -65,8 +70,8 @@ public:
     // stored embedding) even though they are morally const.
     ::renf_t & renf_t() const noexcept { return nf; }
 
-    [[deprecated("Use renf_t() instead.")]] renf * get_renf() noexcept { return nf; }
-    [[deprecated("Use set_pword() instead.")]] std::istream & set_istream(std::istream &) noexcept;
+    [[deprecated("Use renf_t() instead.")]] renf * get_renf() const noexcept { return nf; }
+    [[deprecated("Use set_pword() instead.")]] std::istream & set_istream(std::istream &) const noexcept;
 
 private:
     // The name of the generator
@@ -100,21 +105,21 @@ public:
     // The zero element in k; note that all overloads that take the field as a
     // parameter hold a non-owning reference to the field, i.e., the element is
     // only valid while that reference is.
-    explicit renf_elem_class(const renf_class & k) noexcept;
+    explicit renf_elem_class(std::shared_ptr<const renf_class> k) noexcept;
     // An integer in the field k
-    renf_elem_class(const renf_class & k, const mpz_class &) noexcept;
+    renf_elem_class(std::shared_ptr<const renf_class> k, const mpz_class &) noexcept;
     // A rational in the field k
-    renf_elem_class(const renf_class & k, const mpq_class &) noexcept;
+    renf_elem_class(std::shared_ptr<const renf_class> k, const mpq_class &) noexcept;
     // A rational in the field k
-    renf_elem_class(const renf_class & k, const fmpq_t) noexcept;
+    renf_elem_class(std::shared_ptr<const renf_class> k, const fmpq_t) noexcept;
     // An integer in the field k
     template <typename Integer, typename std::enable_if_t<std::is_integral_v<Integer>, int> = 0>
-    renf_elem_class(const renf_class & k, const Integer) noexcept;
+    renf_elem_class(std::shared_ptr<const renf_class> k, const Integer) noexcept;
     // Parse the string into an element in the field k
-    renf_elem_class(const renf_class & k, const std::string &);
+    renf_elem_class(std::shared_ptr<const renf_class> k, const std::string &);
     // The element Σc_i·α^i where α is the generator of the field k; the number
     // of coefficients must not exceed the degree of the field.
-    template <typename C> renf_elem_class(const renf_class & k, const std::vector<C> &) noexcept;
+    template <typename C> renf_elem_class(std::shared_ptr<const renf_class> k, const std::vector<C> &) noexcept;
 
     ~renf_elem_class() noexcept;
 
@@ -125,7 +130,7 @@ public:
     renf_elem_class & operator=(renf_elem_class &&) noexcept;
 
     // containing number field; holds a nullptr if this is a rational number
-    const renf_class & parent() const noexcept { return *nf; }
+    const std::shared_ptr<const renf_class>& parent() const noexcept { return nf; }
 
     // testing
     bool is_fmpq() const noexcept;
@@ -202,7 +207,7 @@ public:
 
 private:
     // The parent number field; a nullptr if the element is rational.
-    renf_class const * nf;
+    std::shared_ptr<const renf_class> nf;
     // The underlying element when nf != nullptr.
     // We need mutability as calls might need to refine the precision of
     // the stored embedding.
@@ -212,7 +217,7 @@ private:
 
     // Make this->nf == nf; when this->nf != nullptr, only implemented in
     // trivial cases
-    void promote(const renf_class & nf) noexcept;
+    void promote(std::shared_ptr<const renf_class> nf) noexcept;
     template <typename T, typename fmpq_op, typename renf_op>
     int cmp(T && rhs, fmpq_op fmpq, renf_op renf) const noexcept;
     template <typename T, typename fmpq_op, typename renf_op> void inplace_binop(T && rhs, fmpq_op fmpq, renf_op renf);
@@ -287,8 +292,8 @@ renf_elem_class::renf_elem_class(Integer value) noexcept
 }
 
 template <typename Coefficient>
-renf_elem_class::renf_elem_class(const renf_class & k, const std::vector<Coefficient> & coefficients) noexcept
-    : renf_elem_class(k)
+renf_elem_class::renf_elem_class(const std::shared_ptr<const renf_class> k, const std::vector<Coefficient> & coefficients) noexcept
+    : renf_elem_class(std::move(k))
 {
 #ifdef __GNUG__
 #pragma GCC diagnostic push
@@ -326,10 +331,10 @@ renf_elem_class::renf_elem_class(const renf_class & k, const std::vector<Coeffic
 }
 
 template <typename Integer, typename std::enable_if_t<std::is_integral_v<Integer>, int>>
-renf_elem_class::renf_elem_class(const renf_class & k, Integer value) noexcept
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, Integer value) noexcept
 {
-    nf = &k;
-    renf_elem_init(a, k.renf_t());
+    nf = std::move(k);
+    renf_elem_init(a, nf->renf_t());
 
     assign(to_supported_integer<true>(value));
 }

--- a/renfxx/renf_class.cpp
+++ b/renfxx/renf_class.cpp
@@ -42,18 +42,13 @@ renf_class::renf_class() noexcept
     name = "a";
 }
 
-renf_class::renf_class(const renf_class & k) noexcept
-    : renf_class(k.renf_t(), k.gen_name())
-{
-}
-
 renf_class::renf_class(const ::renf_t k, const std::string & gen_name) noexcept
 {
     renf_init_set(nf, k);
     this->name = gen_name;
 }
 
-renf_class::renf_class(const std::string & minpoly, const std::string & gen, const std::string emb, const slong prec)
+renf_class::renf_class(const std::string & minpoly, const std::string & gen, const std::string & emb, const slong prec)
 {
     arb_t e;
     fmpq_poly_t p;
@@ -79,6 +74,21 @@ renf_class::renf_class(const std::string & minpoly, const std::string & gen, con
     arb_clear(e);
 }
 
+std::shared_ptr<const renf_class> renf_class::make() noexcept
+{
+    return std::shared_ptr<const renf_class>(new renf_class());
+}
+
+std::shared_ptr<const renf_class> renf_class::make(const ::renf_t k, const std::string & gen_name) noexcept
+{
+    return std::shared_ptr<const renf_class>(new renf_class(k, gen_name));
+}
+
+std::shared_ptr<const renf_class> renf_class::make(const std::string & minpoly, const std::string & gen, const std::string & emb, const slong prec)
+{
+    return std::shared_ptr<const renf_class>(new renf_class(minpoly, gen, emb, prec));
+}
+
 renf_class::~renf_class() noexcept { renf_clear(nf); }
 
 renf_class & renf_class::operator=(const renf_class & k) noexcept
@@ -96,19 +106,19 @@ slong renf_class::degree() const noexcept { return nf_degree(nf->nf); }
 
 renf_elem_class renf_class::zero() const noexcept
 {
-    renf_elem_class a(*this, 0);
+    renf_elem_class a(this->shared_from_this(), 0);
     return a;
 }
 
 renf_elem_class renf_class::one() const noexcept
 {
-    renf_elem_class a(*this, 1);
+    renf_elem_class a(this->shared_from_this(), 1);
     return a;
 }
 
 renf_elem_class renf_class::gen() const noexcept
 {
-    renf_elem_class a(*this);
+    renf_elem_class a(this->shared_from_this());
     renf_elem_gen(a.renf_elem_t(), this->renf_t());
     return a;
 }
@@ -119,13 +129,13 @@ bool renf_class::operator==(const renf_class & other) const noexcept
       && this->name == other.name;
 }
 
-std::istream & renf_class::set_pword(std::istream & is) noexcept
+std::istream & renf_class::set_pword(std::istream & is) const noexcept
 {
-    is.pword(xalloc) = this;
+    is.pword(xalloc) = (void *) this;
     return is;
 }
 
-std::istream & renf_class::set_istream(std::istream & is) noexcept { return set_pword(is); }
+std::istream & renf_class::set_istream(std::istream & is) const noexcept { return set_pword(is); }
 
 std::string renf_class::to_string() const noexcept
 {
@@ -176,7 +186,7 @@ std::istream & operator>>(std::istream & is, renf_elem_class & a)
             s += is.get();
     }
 
-    a = (nf == nullptr) ? mpq_class(s) : renf_elem_class(*nf, s);
+    a = (nf == nullptr) ? mpq_class(s) : renf_elem_class(nf->shared_from_this(), s);
 
     return is;
 }

--- a/renfxx/renf_elem_class.cpp
+++ b/renfxx/renf_elem_class.cpp
@@ -49,29 +49,29 @@ renf_elem_class::renf_elem_class(const ::fmpq_t value) noexcept
     assign(value);
 }
 
-renf_elem_class::renf_elem_class(const renf_class & k) noexcept
-    : renf_elem_class(k, 0) {}
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k) noexcept
+    : renf_elem_class(std::move(k), 0) {}
 
-renf_elem_class::renf_elem_class(const renf_class & k, const mpz_class & value) noexcept
-    : renf_elem_class(k)
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, const mpz_class & value) noexcept
+    : renf_elem_class(std::move(k))
 {
     assign(value);
 }
 
-renf_elem_class::renf_elem_class(const renf_class & k, const mpq_class & value) noexcept
-    : renf_elem_class(k)
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, const mpq_class & value) noexcept
+    : renf_elem_class(std::move(k))
 {
     assign(value);
 }
 
-renf_elem_class::renf_elem_class(const renf_class & k, const ::fmpq_t value) noexcept
-    : renf_elem_class(k)
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, const ::fmpq_t value) noexcept
+    : renf_elem_class(std::move(k))
 {
     assign(value);
 }
 
-renf_elem_class::renf_elem_class(const renf_class & k, const std::string & str)
-    : renf_elem_class(k)
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, const std::string & str)
+    : renf_elem_class(std::move(k))
 {
     const char * s = str.c_str();
 
@@ -81,13 +81,13 @@ renf_elem_class::renf_elem_class(const renf_class & k, const std::string & str)
 
     if (i != nullptr)
     {
-        t = (char *) flint_malloc((i - s + 1) * sizeof(char));
+        t = static_cast<char *>(flint_malloc((i - s + 1) * sizeof(char)));
         strncpy(t, s, i - s);
         t[i - s] = '\0';
     }
     else
     {
-        t = (char *) flint_malloc((strlen(s) + 1) * sizeof(char));
+        t = static_cast<char *>(flint_malloc((strlen(s) + 1) * sizeof(char)));
         strcpy(t, s);
     }
 
@@ -284,7 +284,7 @@ renf_elem_class::operator mpq_class() const noexcept
         assert(is_rational() && "renf_elem_class not a rational");
         ::fmpq_t q;
         fmpq_init(q);
-        nf_elem_get_fmpq(q, a->elem, parent().renf_t()->nf);
+        nf_elem_get_fmpq(q, a->elem, parent()->renf_t()->nf);
         fmpq_get_mpq(z.__get_mp(), q);
         fmpq_clear(q);
     }
@@ -364,7 +364,7 @@ std::string renf_elem_class::to_string(int flags) const noexcept
     }
     else
     {
-        char * u = renf_elem_get_str_pretty(renf_elem_t(), parent().gen_name().c_str(), parent().renf_t(), 10, flags);
+        char * u = renf_elem_get_str_pretty(renf_elem_t(), parent()->gen_name().c_str(), parent()->renf_t(), 10, flags);
         s += u;
         flint_free(u);
     }
@@ -457,7 +457,7 @@ renf_elem_class & renf_elem_class::operator+=(const renf_elem_class & rhs) noexc
         inplace_binop(rhs.b, fmpq_add, renf_elem_add_fmpq);
     else
     {
-        promote(*rhs.nf);
+        promote(rhs.nf);
         renf_elem_add(a, a, rhs.a, nf->renf_t());
     }
     return *this;
@@ -469,7 +469,7 @@ renf_elem_class & renf_elem_class::operator-=(const renf_elem_class & rhs) noexc
         inplace_binop(rhs.b, fmpq_sub, renf_elem_sub_fmpq);
     else
     {
-        promote(*rhs.nf);
+        promote(rhs.nf);
         renf_elem_sub(a, a, rhs.a, nf->renf_t());
     }
     return *this;
@@ -481,7 +481,7 @@ renf_elem_class & renf_elem_class::operator*=(const renf_elem_class & rhs) noexc
         inplace_binop(rhs.b, fmpq_mul, renf_elem_mul_fmpq);
     else
     {
-        promote(*rhs.nf);
+        promote(rhs.nf);
         renf_elem_mul(a, a, rhs.a, nf->renf_t());
     }
     return *this;
@@ -493,7 +493,7 @@ renf_elem_class & renf_elem_class::operator/=(const renf_elem_class & rhs)
         inplace_binop(rhs.b, fmpq_div, renf_elem_div_fmpq);
     else
     {
-        promote(*rhs.nf);
+        promote(rhs.nf);
         renf_elem_div(a, a, rhs.a, nf->renf_t());
     }
     return *this;
@@ -503,7 +503,7 @@ renf_elem_class renf_elem_class::pow(int exp) const noexcept
 {
     renf_elem_class res(parent());
 
-    renf_elem_pow_si(res.renf_elem_t(), renf_elem_t(), exp, parent().renf_t());
+    renf_elem_pow_si(res.renf_elem_t(), renf_elem_t(), exp, parent()->renf_t());
 
     return res;
 }
@@ -574,7 +574,7 @@ std::vector<mpz_class> renf_elem_class::get_num_vector(void) const noexcept { re
 
 double renf_elem_class::get_d() const noexcept { return static_cast<double>(*this); }
 
-void renf_elem_class::promote(const renf_class & nf) noexcept
+void renf_elem_class::promote(std::shared_ptr<const renf_class> nf) noexcept
 {
     if (is_fmpq())
     {
@@ -584,7 +584,7 @@ void renf_elem_class::promote(const renf_class & nf) noexcept
     }
     else
     {
-        if (*this->nf == nf)
+        if (*this->nf == *nf)
             return;
         else
 #ifdef __GNUG__

--- a/renfxx/test/t-assignment.cpp
+++ b/renfxx/test/t-assignment.cpp
@@ -25,7 +25,7 @@ int main(void)
     {
         renf_t nf;
         renf_randtest(nf, state, 10, 64, 10);
-        renf_class K(nf);
+        auto K = renf_class::make(nf);
 
         renf_clear(nf);
 
@@ -162,7 +162,7 @@ int main(void)
         }
 
         {
-            if (K.degree() >= 2)
+            if (K->degree() >= 2)
             {
                 std::vector<mpz_class> v;
                 v.push_back(1);
@@ -171,13 +171,13 @@ int main(void)
                 renf_elem_class b(K);
                 b = renf_elem_class(b.parent(), v);
 
-                if (a != K.gen() + 1 || b != K.gen() + 1)
+                if (a != K->gen() + 1 || b != K->gen() + 1)
                     throw std::runtime_error("constructor from std::vector<mpz_class> failed");
             }
         }
 
         {
-            if (K.degree() >= 2)
+            if (K->degree() >= 2)
             {
                 std::vector<mpq_class> v;
                 v.push_back(mpq_class(1,2));
@@ -186,8 +186,8 @@ int main(void)
                 renf_elem_class b(K,v);
                 b = renf_elem_class(b.parent(), v);
 
-                if (a != (-2*K.gen()/3 + mpq_class(1,2)) ||
-                    b != (-2*K.gen()/3 + mpq_class(1,2)))
+                if (a != (-2*K->gen()/3 + mpq_class(1,2)) ||
+                    b != (-2*K->gen()/3 + mpq_class(1,2)))
                     throw std::runtime_error("constructor from std::vector<mpq_class> failed");
             }
         }

--- a/renfxx/test/t-binop.cpp
+++ b/renfxx/test/t-binop.cpp
@@ -76,7 +76,7 @@ using namespace eantic;
 }
 
 template <typename T>
-typename std::enable_if<std::is_unsigned<T>::value, void>::type check_binop(T a, T b, renf_class& K)
+typename std::enable_if<std::is_unsigned<T>::value, void>::type check_binop(T a, T b, std::shared_ptr<const renf_class> K)
 {
     CHECK_OP(a, b, K, T, +);
     CHECK_OP(a, b, K, T, *);
@@ -85,7 +85,7 @@ typename std::enable_if<std::is_unsigned<T>::value, void>::type check_binop(T a,
 }
 
 template <typename T>
-typename std::enable_if<!std::is_unsigned<T>::value, void>::type check_binop(T a, T b, renf_class& K)
+typename std::enable_if<!std::is_unsigned<T>::value, void>::type check_binop(T a, T b, std::shared_ptr<const renf_class> K)
 {
     CHECK_OP(a, b, K, T, +);
     CHECK_OP(a, b, K, T, -);
@@ -105,7 +105,7 @@ int main(void)
     {
         renf_t nf;
         renf_randtest(nf, state, 10, 32, 50);
-        renf_class K(nf);
+        auto K = renf_class::make(nf);
         renf_clear(nf);
 
         {
@@ -137,20 +137,20 @@ int main(void)
     }
 
     {
-        renf_class K1("x^2 - 2", "x", "1.41 +/- 0.01");
-        renf_class K2("x^2 - 3", "x", "1.73 +/- 0.01");
+        auto K1 = renf_class::make("x^2 - 2", "x", "1.41 +/- 0.01");
+        auto K2 = renf_class::make("x^2 - 3", "x", "1.73 +/- 0.01");
 
         renf_elem_class a1(K1);
         renf_elem_class a2(K2);
     }
 
     {
-        renf_class K("x^2 - 2", "x", "1.41 +/- 0.01");
+        auto K = renf_class::make("x^2 - 2", "x", "1.41 +/- 0.01");
 
         renf_elem_class a(K, "1/3 + 3/5*x");
-        renf_elem_class b = mpq_class(1,3) + mpq_class(3,5) * K.gen();
-        renf_elem_class c = mpq_class(1,3) + mpz_class(3) * K.gen() / mpz_class(5);
-        renf_elem_class d = mpq_class(1,3) + 3 * K.gen() / 5;
+        renf_elem_class b = mpq_class(1,3) + mpq_class(3,5) * K->gen();
+        renf_elem_class c = mpq_class(1,3) + mpz_class(3) * K->gen() / mpz_class(5);
+        renf_elem_class d = mpq_class(1,3) + 3 * K->gen() / 5;
 
         if (a != b || a != c || a != d)
             throw std::runtime_error("error with operations");

--- a/renfxx/test/t-ceil.cpp
+++ b/renfxx/test/t-ceil.cpp
@@ -34,7 +34,7 @@ int main(void)
         fmpq_t k;
         fmpq_poly_t p;
 
-        renf_class K("x^2-x-1", "x", "1.618 +/- 0.1");
+        auto K = renf_class::make("x^2-x-1", "x", "1.618 +/- 0.1");
 
         /* (1+sqrt(5))/2 vs Fibonacci */
         renf_elem_class a(K);
@@ -48,7 +48,7 @@ int main(void)
             fmpz_fib_ui(fmpq_numref(k), iter+1);
             fmpz_fib_ui(fmpq_denref(k), iter);
             fmpq_poly_set_coeff_fmpq(p, 0, k);
-            renf_elem_set_fmpq_poly(a.get_renf_elem(), p, K.get_renf());
+            renf_elem_set_fmpq_poly(a.get_renf_elem(), p, K->get_renf());
 
             if (a.ceil() != 1 - iter % 2)
             {

--- a/renfxx/test/t-cmp.cpp
+++ b/renfxx/test/t-cmp.cpp
@@ -14,7 +14,7 @@
 using namespace eantic;
 
 template<typename T>
-void check_eq_ne(T t, renf_class& K)
+void check_eq_ne(T t, std::shared_ptr<const renf_class> K)
 {
     renf_elem_class a;
     a = t;
@@ -26,7 +26,7 @@ void check_eq_ne(T t, renf_class& K)
 
     renf_elem_class d(K, t);
 
-    renf_class L(K);
+    auto L = K;
     renf_elem_class e(L, t);
 
     #define test_neq(x,y) (x != y) || (y != x) || not (x == y) || not (y == x)
@@ -50,10 +50,10 @@ void check_eq_ne(T t, renf_class& K)
 }
 
 template<typename T>
-void check_not_gen(T t, renf_class& K)
+void check_not_gen(T t, std::shared_ptr<const renf_class> K)
 {
     renf_elem_class a(K);
-    renf_elem_gen(a.get_renf_elem(), K.get_renf());
+    renf_elem_gen(a.get_renf_elem(), K->get_renf());
 
     if (a == t || t == a ||
         not (a != t) || not (t != a) ||
@@ -67,7 +67,7 @@ void check_not_gen(T t, renf_class& K)
 }
 
 template<typename T>
-void check_order(T c1, T c2, renf_class& K)
+void check_order(T c1, T c2, std::shared_ptr<const renf_class> K)
 {
     renf_elem_class a1(K, c1);
     renf_elem_class a2(K, c2);
@@ -99,7 +99,7 @@ int main(void)
     {
         renf_t nf;
         renf_randtest(nf, state, 5, 64, 10);
-        renf_class K(nf);
+        auto K = renf_class::make(nf);
         renf_clear(nf);
 
         check_eq_ne(c1, K);
@@ -119,7 +119,7 @@ int main(void)
     {
         renf_t nf;
         renf_randtest(nf, state, 5, 64, 10);
-        renf_class K(nf);
+        auto K = renf_class::make(nf);
         renf_clear(nf);
 
         check_order((int) -1, (int) 1, K);

--- a/renfxx/test/t-constructor.cpp
+++ b/renfxx/test/t-constructor.cpp
@@ -62,25 +62,24 @@ int main(void)
 
     {
         // operator = for renf_class
-        renf_class K1("a^2 - 2", "a", "1.41 +/- 0.1", 128);
-        renf_class K2;
-        K2 = K1;
+        auto K1 = renf_class::make("a^2 - 2", "a", "1.41 +/- 0.1", 128);
+        auto K2 = K1;
 
         renf_elem_class a(K1, "a + 1");
         renf_elem_class b(K2, "a + 1");
 
-        if (K1.degree() != 2 || K2.degree() != 2)
+        if (K1->degree() != 2 || K2->degree() != 2)
             throw std::runtime_error("wrong answer for degree");
     }
 
     {
         renf_t nf;
         renf_randtest(nf, state, 10, 128, 50);
-        renf_class K(nf);
+        auto K = renf_class::make(nf);
 
         renf_elem_class a(K);
         renf_elem_class b(a);
-        renf_elem_class c = K.zero();
+        renf_elem_class c = K->zero();
 
         if (a.is_fmpq() || b.is_fmpq() || c.is_fmpq())
             throw std::runtime_error("problem with renf_elem_class constructor");
@@ -94,12 +93,12 @@ int main(void)
     }
 
     {
-        renf_class K("a^2 - 2", "a", "1.4142 +/- 0.5", 128);
+        auto K = renf_class::make("a^2 - 2", "a", "1.4142 +/- 0.5", 128);
         renf_elem_class a(K);
         renf_elem_class b(K, 0);
         renf_elem_class c(K, "0");
         renf_elem_class d(K, "0*a^2 + 0");
-        renf_elem_class e = K.zero();
+        renf_elem_class e = K->zero();
 
         if (a.is_fmpq() || b.is_fmpq() || c.is_fmpq() || d.is_fmpq() || e.is_fmpq())
             throw std::runtime_error("problem with renf_elem_class constructor");
@@ -112,11 +111,11 @@ int main(void)
 
     {
         // QQ
-        renf_class K;
+        auto K = renf_class::make();
         renf_elem_class a(K);
         renf_elem_class b(K, 0);
         renf_elem_class c(K, "0");
-        renf_elem_class d = K.zero();
+        renf_elem_class d = K->zero();
 
         check_equal(a, b);
         check_equal(a, c);
@@ -125,20 +124,20 @@ int main(void)
 
     {
         // QQ[sqrt(2)]
-        renf_class K("a^2 - 2", "a", "1.41 +/- 0.1", 128);
+        auto K = renf_class::make("a^2 - 2", "a", "1.41 +/- 0.1", 128);
 
         renf_elem_class a(K, "-7/3 + 3/5*a");
-        renf_elem_class b = 3 * K.gen() / 5 - 7 * K.one() / 3;
+        renf_elem_class b = 3 * K->gen() / 5 - 7 * K->one() / 3;
 
         check_equal(a, b);
     }
 
     {
         // QQ[cbrt(2)]
-        renf_class K("A^3 - 2", "A", "1.26 +/- 0.1");
+        auto K = renf_class::make("A^3 - 2", "A", "1.26 +/- 0.1");
 
         renf_elem_class a(K, "2/5 - 3/2 * A + 7/4 * A^2");
-        renf_elem_class b = mpq_class(2, 5) - mpq_class(3, 2) * K.gen() + mpq_class(7, 4) * K.gen() * K.gen();
+        renf_elem_class b = mpq_class(2, 5) - mpq_class(3, 2) * K->gen() + mpq_class(7, 4) * K->gen() * K->gen();
 
         check_equal(a, b);
     }

--- a/renfxx/test/t-get.cpp
+++ b/renfxx/test/t-get.cpp
@@ -43,7 +43,7 @@ int main(void)
 
         renf_t nf;
         renf_randtest(nf, state, 5, 64, 50);
-        renf_class K(nf);
+        auto K = renf_class::make(nf);
         renf_clear(nf);
 
         renf_elem_class a(K);

--- a/renfxx/test/t-get_num_den.cpp
+++ b/renfxx/test/t-get_num_den.cpp
@@ -20,7 +20,7 @@
 
 using namespace eantic;
 
-void check_rational(int num, int den, renf_class& K)
+void check_rational(int num, int den, std::shared_ptr<const renf_class> K)
 {
     renf_elem_class a(K);
     a = num;
@@ -34,15 +34,15 @@ void check_rational(int num, int den, renf_class& K)
     }
 }
 
-void check_reconstruct(renf_class& K, renf_elem_class& a)
+void check_reconstruct(std::shared_ptr<const renf_class> K, renf_elem_class& a)
 {
-    renf_elem_class g = K.gen();
+    renf_elem_class g = K->gen();
     renf_elem_class gg = 1;
     renf_elem_class b = 0;
 
     std::cerr << "bx = " << b << std::endl;
     std::vector<mpz_class> num = a.get_num_vector();
-    if (num.size() != K.degree())
+    if (num.size() != K->degree())
         throw std::runtime_error("wrong vector length");
     for (std::vector<mpz_class>::iterator it = num.begin(); it < num.end(); it++)
     {
@@ -73,7 +73,7 @@ int main(void)
 {
     {
         // linear
-        renf_class K("x - 2/3", "x", "0.66 +/- 0.1");
+        auto K = renf_class::make("x - 2/3", "x", "0.66 +/- 0.1");
 
         check_rational(-12, 5, K);
 
@@ -86,7 +86,7 @@ int main(void)
 
     {
         // quadratic
-        renf_class K("x^2 - 2", "x", "1.41 +/- 0.1");
+        auto K = renf_class::make("x^2 - 2", "x", "1.41 +/- 0.1");
 
         check_rational(7, 12, K);
 
@@ -102,7 +102,7 @@ int main(void)
 
     {
         // cubic
-        renf_class K("ZT^3 - 2/5", "ZT", "0.74 +/- 0.1");
+        auto K = renf_class::make("ZT^3 - 2/5", "ZT", "0.74 +/- 0.1");
 
         renf_elem_class a(K, 0);
         check_reconstruct(K, a);

--- a/renfxx/test/t-get_str.cpp
+++ b/renfxx/test/t-get_str.cpp
@@ -50,7 +50,7 @@ int main(void)
 
     {
         // quadratic example
-        renf_class K("x^2 - 2", "x", "1.41 +/- 0.1");
+        auto K = renf_class::make("x^2 - 2", "x", "1.41 +/- 0.1");
 
         {
             renf_elem_class a(K, "0");
@@ -74,7 +74,7 @@ int main(void)
 
     {
         // cubic example
-        renf_class K("x^3 - 2/3", "x", "0.87 +/- 0.1");
+        auto K = renf_class::make("x^3 - 2/3", "x", "0.87 +/- 0.1");
 
         {
             renf_elem_class a(K, "0");

--- a/renfxx/test/t-is_integer_rational.cpp
+++ b/renfxx/test/t-is_integer_rational.cpp
@@ -35,14 +35,14 @@ int main(void)
     {
         renf_t nf;
         renf_randtest(nf, state, 5, 32, 20);
-        renf_class K(nf);
+        auto K = renf_class::make(nf);
         renf_clear(nf);
 
         if (fmpq_poly_length(nf->nf->pol) <= 1)
             continue;
 
         renf_elem_class a(K);
-        renf_elem_gen(a.get_renf_elem(), K.get_renf());
+        renf_elem_gen(a.get_renf_elem(), K->get_renf());
 
         if (a.is_integer() || a.is_rational())
             throw 10;

--- a/renfxx/test/t-pow.cpp
+++ b/renfxx/test/t-pow.cpp
@@ -25,7 +25,7 @@ int main(void)
     {
         renf_t nf;
         renf_randtest(nf, state, 10, 64, 10);
-        renf_class K(nf);
+        auto K = renf_class::make(nf);
         renf_clear(nf);
 
         {
@@ -38,7 +38,7 @@ int main(void)
         }
 
         {
-            renf_elem_class a = K.gen();
+            renf_elem_class a = K->gen();
             if (a.pow(5) * a.pow(-5) != 1)
                 std::runtime_error("a^5 is wrong");
         }

--- a/renfxx/test/t-stream.cpp
+++ b/renfxx/test/t-stream.cpp
@@ -18,26 +18,26 @@ using namespace eantic;
 
 int main(void)
 {
-    renf_class K1("A^3 - 2", "A", "1.25 +/- 0.1");
-    renf_class K2("2*abc^4 - 5*abc + 1", "abc", "0.2 +/- 0.1");
+    auto K1 = renf_class::make("A^3 - 2", "A", "1.25 +/- 0.1");
+    auto K2 = renf_class::make("2*abc^4 - 5*abc + 1", "abc", "0.2 +/- 0.1");
 
 
     {
         std::stringstream s;
-        s << K1;
+        s << *K1;
         if (s.str() != "NumberField(A^3 - 2, [1.25992104989487316476721061 +/- 4.87e-27])")
             throw std::runtime_error("wrong K1 string, got " + s.str());
     }
 
     {
         std::stringstream s;
-        s << K2;
+        s << *K2;
         if (s.str() != "NumberField(2*abc^4 - 5*abc + 1, [0.200648339181800500946306030432 +/- 2.64e-31])")
             throw std::runtime_error("wrong K2 string, got " + s.str());
     }
 
-    const renf_elem_class g1 = K1.gen();
-    const renf_elem_class g2 = K2.gen();
+    const renf_elem_class g1 = K1->gen();
+    const renf_elem_class g2 = K2->gen();
 
     {
         std::stringstream s;
@@ -57,7 +57,7 @@ int main(void)
 
     {
         std::stringstream s;
-        renf_elem_class a = K1.gen();
+        renf_elem_class a = K1->gen();
         s << a;
         if (s.str() != "(A ~ 1.259921)")
             throw std::runtime_error("wrong string, got " + s.str());
@@ -67,13 +67,13 @@ int main(void)
         renf_elem_class a(K1);
 
         std::stringstream sin1("3/5*A+2");
-        K1.set_pword(sin1);
+        K1->set_pword(sin1);
         sin1 >> a;
         if (a != 3*g1/5 + 2)
             throw std::runtime_error("wrong nf initialization");
 
         std::stringstream sin2("A-1");
-        K1.set_pword(sin2);
+        K1->set_pword(sin2);
         sin2 >> a;
         if (a != g1 - 1)
             throw std::runtime_error("wrong nf reinitialization");
@@ -94,17 +94,17 @@ int main(void)
         renf_elem_class a;
 
         std::stringstream sin1("3*A^2-7");
-        K1.set_istream(sin1) >> a;
+        K1->set_istream(sin1) >> a;
         if (a != 3*g1*g1-7)
             throw std::runtime_error("bad stream_set_renf initialization");
 
         std::stringstream sin2("A+1");
-        K1.set_istream(sin2) >> a;
+        K1->set_istream(sin2) >> a;
         if (a != g1+1)
             throw std::runtime_error("bad stream_set_renf reinitialization 1");
 
         std::stringstream sin3("abc^2-1");
-        K2.set_istream(sin3) >> a;
+        K2->set_istream(sin3) >> a;
         if (a != g2*g2 - 1)
             throw std::runtime_error("bad stream_set_renf reinitialization 2");
     }
@@ -116,7 +116,7 @@ int main(void)
         std::stringstream s;
 
         s << a;
-        K1.set_pword(s);
+        K1->set_pword(s);
         s >> b;
 
         if (a != b)


### PR DESCRIPTION
so cppyy can destroy objects in the right order, e.g., when closing a
Sage session.