### PR TITLE
Make type guards collision safe

### DIFF
--- a/e-antic/renf.h
+++ b/e-antic/renf.h
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NF_EMB_H
-#define NF_EMB_H
+#ifndef E_ANTIC_RENF_H
+#define E_ANTIC_RENF_H
 
 #include <flint/fmpq_poly.h>
 #include <e-antic/e-antic.h>

--- a/e-antic/renf_elem.h
+++ b/e-antic/renf_elem.h
@@ -10,8 +10,8 @@
 */
 
 
-#ifndef NF_EMB_ELEM_H
-#define NF_EMB_ELEM_H
+#ifndef E_ANTIC_RENF_ELEM_H
+#define E_ANTIC_RENF_ELEM_H
 
 #include <flint/fmpq_poly.h>
 #include <arb.h>

--- a/e-antic/renfxx.h
+++ b/e-antic/renfxx.h
@@ -11,8 +11,8 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
-#ifndef RENFXX_H
-#define RENFXX_H
+#ifndef E_ANTIC_RENFXX_H
+#define E_ANTIC_RENFXX_H
 
 #include <vector>
 #include <type_traits>

--- a/e-antic/renfxx_cereal.h
+++ b/e-antic/renfxx_cereal.h
@@ -10,8 +10,8 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
-#ifndef RENFXX_CEREAL_H
-#define RENFXX_CEREAL_H
+#ifndef E_ANTIC_RENFXX_CEREAL_H
+#define E_ANTIC_RENFXX_CEREAL_H
 
 #include <cereal/cereal.hpp>
 #include <cereal/types/memory.hpp>

--- a/e-antic/renfxx_fwd.h
+++ b/e-antic/renfxx_fwd.h
@@ -10,8 +10,8 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
-#ifndef RENFXX_FWD_H
-#define RENFXX_FWD_H
+#ifndef E_ANTIC_RENFXX_FWD_H
+#define E_ANTIC_RENFXX_FWD_H
 
 // This file contains forward declarations for all the C++ classes defined by
 // renfxx.h to speed up compilation when included in header files.


### PR DESCRIPTION
at least the ones that actually guard e-antic headers

fixes #31.