### PR TITLE
Remove renf_class_cereal hack

### DIFF
--- a/e-antic/renfxx_cereal.h
+++ b/e-antic/renfxx_cereal.h
@@ -18,23 +18,59 @@
 #include <e-antic/renfxx.h>
 
 namespace eantic {
+template <class Archive>
+void save(Archive & archive, const std::shared_ptr<const renf_class> & self)
+{
+    uint32_t id = archive.registerSharedPointer(self.get());
 
-class renf_class_cereal {
-  public:
-    std::shared_ptr<const renf_class> wrapped;
-
-  private:  
-    friend cereal::access;
-    template <typename Archive>
-    void load(Archive & archive, std::uint32_t version)
+    archive(cereal::make_nvp("shared", id));
+    if ( id & cereal::detail::msb_32bit )
     {
-        if (version != 0) throw std::logic_error("unknown serialization from the future");
+        // This is the first time cereal sees this renf_class, so we actually
+        // store it. Future copies only need the id to resolve to a shared_ptr
+        // to the same renf_class.
+        bool rational = !static_cast<bool>(self);
+        archive(cereal::make_nvp("rational", rational));
+        if (rational)
+        {
+            return;
+        }
+        else
+        {
+            char * emb = arb_get_str(self->renf_t()->emb, arf_bits(arb_midref(self->renf_t()->emb)), 0);
+            char * pol = fmpq_poly_get_str_pretty(self->renf_t()->nf->pol, self->gen_name().c_str());
 
+            archive(
+                cereal::make_nvp("name", self->gen_name()),
+                cereal::make_nvp("embedding", std::string(emb)),
+                cereal::make_nvp("minpoly", std::string(pol)),
+                cereal::make_nvp("precision", self->renf_t()->prec));
+
+            flint_free(pol);
+            flint_free(emb);
+        }
+    }
+}
+
+template <class Archive>
+void load(Archive & archive, std::shared_ptr<const renf_class> & self)
+{
+    // cereal insists on creating a new instance of T when deserializing a
+    // shared_ptr<T>. However this is not compatible with our uniqueness of
+    // renf_class (if the field already exists, we do not create a new one but
+    // just return a shared_ptr to the existing one.) Therefore, we hook into
+    // cereal's deduplication logic for a compact output format but do not rely
+    // on its deserialization for renf_class.
+    uint32_t id;
+    archive(cereal::make_nvp("shared", id));
+
+    if ( id & cereal::detail::msb_32bit )
+    {
         bool rational;
         archive(rational);
         if (rational)
         {
-            wrapped = nullptr;
+            self = nullptr;
         }
         else
         {
@@ -43,66 +79,49 @@ class renf_class_cereal {
             
             archive(name, emb, pol, prec);
 
-            wrapped = renf_class::make(pol, name, emb, prec);
+            self = renf_class::make(pol, name, emb, prec);
         }
-    }
 
-    template <typename Archive>
-    void save(Archive & archive, std::uint32_t) const
+        // Register this number field so other copies in the serialization
+        // resolve to it. cereal stores shared_ptr<void> internally, so we
+        // need to cast away constness and then to void*.
+        archive.registerSharedPointer(id,
+            std::reinterpret_pointer_cast<void>(
+            std::const_pointer_cast<renf_class>(self)));
+    }
+    else
     {
-        bool rational = !static_cast<bool>(wrapped);
-        archive(cereal::make_nvp("rational", rational));
-        if (rational)
-        {
-            return;
-        }
-        else
-        {
-            char * emb = arb_get_str(wrapped->renf_t()->emb, arf_bits(arb_midref(wrapped->renf_t()->emb)), 0);
-            char * pol = fmpq_poly_get_str_pretty(wrapped->renf_t()->nf->pol, wrapped->gen_name().c_str());
-
-            archive(
-                cereal::make_nvp("name", wrapped->gen_name()),
-                cereal::make_nvp("embedding", std::string(emb)),
-                cereal::make_nvp("minpoly", std::string(pol)),
-                cereal::make_nvp("precision", wrapped->renf_t()->prec));
-
-            flint_free(pol);
-            flint_free(emb);
-        }
+        // Resolve to a copy that was previously defined in the serialization.
+        // Since cereal stores that copy as a void pointer, we have to cast it
+        // to a shared_ptr of the correct type first.
+        self = std::static_pointer_cast<renf_class>(archive.getSharedPointer(id));
     }
-};
-
-template <class Archive>
-void serialize(Archive &, renf_class &, std::uint32_t)
-{
-    static_assert(false_t<Archive>, "Cannot serialize renf_class directly with cereal as this breaks deduplication of equal fields upon deseralization. Wrap the renf_class in a renf_class_cereal instead.");
 }
 
 template <class Archive>
-void save(Archive & archive, const renf_elem_class& self, std::uint32_t)
+void save(Archive & archive, const renf_elem_class & self, std::uint32_t)
 {
     archive(
-        cereal::make_nvp("parent", renf_class_cereal{self.parent()}),
+        cereal::make_nvp("parent", self.parent()),
         cereal::make_nvp("value", boost::lexical_cast<std::string>(self)),
         cereal::make_nvp("double", static_cast<double>(self)));
 }
 
 template <class Archive>
-void load(Archive & archive, renf_elem_class& self, std::uint32_t version)
+void load(Archive & archive, renf_elem_class & self, std::uint32_t version)
 {
     if (version != 0) throw std::logic_error("unknown serialization from the future");
 
-    renf_class_cereal nf;
+    std::shared_ptr<const renf_class> nf;
     std::string serialized_element;
     double _;
     
     archive(nf, serialized_element, _);
 
     std::stringstream ss(serialized_element);
-    if (nf.wrapped)
+    if (nf)
     {
-        nf.wrapped->set_pword(ss);
+        nf->set_pword(ss);
     }
     ss >> self;
 }


### PR DESCRIPTION
and instead hook into cereal's shared_ptr serialization logic
(undocumented but part of the public API except for the "detail" which
is just 1 << 31.