### PR TITLE
Minor performance tweak for the C++ interface

### DIFF
--- a/e-antic/renfxx.h
+++ b/e-antic/renfxx.h
@@ -295,13 +295,7 @@ template <bool fallback_to_string, typename Integer> auto to_supported_integer(I
 }
 
 template <typename Integer, typename std::enable_if_t<std::is_integral_v<Integer>, int>>
-renf_elem_class::renf_elem_class(Integer value) noexcept
-{
-    nf = nullptr;
-    fmpq_init(b);
-
-    assign(to_supported_integer<true>(value));
-}
+renf_elem_class::renf_elem_class(Integer value) noexcept : renf_elem_class(nullptr, value) {}
 
 template <typename Coefficient>
 renf_elem_class::renf_elem_class(const std::shared_ptr<const renf_class> k, const std::vector<Coefficient> & coefficients) noexcept
@@ -338,7 +332,10 @@ template <typename Integer, typename std::enable_if_t<std::is_integral_v<Integer
 renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, Integer value) noexcept
 {
     nf = std::move(k);
-    renf_elem_init(a, nf->renf_t());
+    if (nf)
+      renf_elem_init(a, nf->renf_t());
+    else
+      fmpq_init(b);
 
     assign(to_supported_integer<true>(value));
 }

--- a/renfxx/renf_elem_class.cpp
+++ b/renfxx/renf_elem_class.cpp
@@ -21,13 +21,13 @@ renf_elem_class::renf_elem_class() noexcept
 }
 
 renf_elem_class::renf_elem_class(const renf_elem_class & value) noexcept
-    : renf_elem_class()
+    : renf_elem_class(value.nf)
 {
     *this = value;
 }
 
 renf_elem_class::renf_elem_class(renf_elem_class && value) noexcept
-    : renf_elem_class()
+    : renf_elem_class(value.nf)
 {
     *this = std::move(value);
 }
@@ -133,7 +133,7 @@ renf_elem_class & renf_elem_class::operator=(const renf_elem_class & value) noex
             renf_elem_init(a, value.nf->renf_t());
             nf = value.nf;
         }
-        else if (*value.nf != *nf)
+        else if (value.nf != nf)
         {
             renf_elem_clear(a, nf->renf_t());
             renf_elem_init(a, value.nf->renf_t());


### PR DESCRIPTION
this should speed up the operator= in some typical use cases.

Note that we do not need to dereference nf since we assume uniqueness
of renf_class, i.e., if the address is the same, we assume that the
content is the same.