### PR TITLE
Follow best practices when including config.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,5 @@
 AUTOMAKE_OPTIONS = subdir-objects
 ACLOCAL_AMFLAGS = -I m4
-
 # Installed library (libtool (LT) libraries)
 lib_LTLIBRARIES = libeantic.la libeanticxx.la
 libeantic_la_LDFLAGS = -version-info @libeantic_version_info@ -no-undefined
@@ -12,6 +11,9 @@ libeanticxx_la_LIBADD = libeantic.la -lgmpxx -lflint
 
 # Installed headers
 nobase_include_HEADERS = e-antic/nf.h e-antic/nf_elem.h e-antic/renf.h e-antic/renf_elem.h e-antic/poly_extra.h e-antic/renfxx.h e-antic/renfxx_fwd.h e-antic/renfxx_cereal.h
+
+# Put config.h on the search path, https://www.gnu.org/software/automake/manual/html_node/VPATH-Builds.html
+AM_CPPFLAGS = -I.
 
 # Initialize variables, to be filled below
 noinst_HEADERS =

--- a/renf/refine_embedding.c
+++ b/renf/refine_embedding.c
@@ -9,11 +9,10 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
 #include <err.h>
 #include <e-antic/poly_extra.h>
 #include <e-antic/renf.h>
-
-#include "../config.h"
 
 #ifdef HAVE_PTHREAD
 #include <pthread.h>


### PR DESCRIPTION
This caused trouble for me in a VPATH build.

quoting from https://www.gnu.org/software/autoconf/manual/autoconf-2.61/html_node/Configuration-Headers.html

```
The package should `#include' the configuration header file before any
other header files, to prevent inconsistencies in declarations (for
example, if it redefines const).

To provide for VPATH builds, remember to pass the C compiler a -I.
option (or -I..; whichever directory contains config.h). Even if you use
`#include "config.h"', the preprocessor searches only the directory of
the currently read file, i.e., the source directory, not the build
directory.

With the appropriate -I option, you can use `#include <config.h>'.
Actually, it's a good habit to use it, because in the rare case when the
source directory contains another config.h, the build directory should
be searched first.
```