### PR TITLE
Remove HEREDOC from travis.yml

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -exo pipefail
+export MAKEFLAGS="-j2"
+apt-get update
+apt-get -y install libgmp-dev libmpfr-dev libflint-dev valgrind libflint-arb-dev libboost-all-dev libtool make autoconf $PACKAGES
+./bootstrap.sh
+./configure --prefix=/usr --enable-valgrind ${CONFIGURE} || (cat config.log; false)
+make
+ldd .libs/libeantic.so
+make check || (cat `find test-suite.log`; false)
+make check-valgrind || (cat `find test-suite-memcheck.log`; false)
+make distcheck

--- a/.travis.sh
+++ b/.travis.sh
@@ -7,6 +7,6 @@ apt-get -y install libgmp-dev libmpfr-dev libflint-dev valgrind libflint-arb-dev
 ./configure --prefix=/usr --enable-valgrind ${CONFIGURE} || (cat config.log; false)
 make
 ldd .libs/libeantic.so
-make check || (cat `find test-suite.log`; false)
-make check-valgrind || (cat `find test-suite-memcheck.log`; false)
+make check || (cat `find test-suite.log` /dev/null; false)
+make check-valgrind || (cat `find test-suite-memcheck.log` /dev/null; false)
 make distcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,4 @@ env:
 services:
   - docker
 script:
-  - |
-    docker run -i -e CC -e CXX -e PACKAGES -v ${TRAVIS_BUILD_DIR}:/eantic -w /eantic ubuntu:cosmic <<-"EOF"
-      set -exo pipefail
-      export MAKEFLAGS="-j2"
-      apt-get update
-      apt-get -y install libgmp-dev libmpfr-dev libflint-dev valgrind libflint-arb-dev libboost-all-dev libtool make autoconf $PACKAGES
-      ./bootstrap.sh
-      ./configure --prefix=/usr --enable-valgrind ${CONFIGURE} || (cat config.log; false)
-      make
-      ldd .libs/libeantic.so
-      make check || (cat `find test-suite.log`; false)
-      make check-valgrind || (cat `find test-suite-memcheck.log`; false)
-      make distcheck
-    EOF
+  - docker run -i -e CC -e CXX -e PACKAGES -v ${TRAVIS_BUILD_DIR}:/eantic -v `pwd`/.travis.sh:/travis.sh -w /eantic ubuntu:cosmic /travis.sh


### PR DESCRIPTION
apparently Travis CI changed recently how they parse HEREDOCs embedded
in the travis configuration file. Strangely, it won't find out EOF
marker anymore. So to work around, we just put the test script into an
actual script and execute it directly instead.

Probably related to this bug report: https://travis-ci.community/t/multiline-commands-have-two-spaces-in-front-breaks-heredocs/2756