### PR TITLE
Backport libeantic*_la_LIBADD changes from master 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # set local directory and check name resolution
   - mkdir local
   - export PREFIX="/usr/local"
-  - export LD_LIBRARY_PATH=${PREFIX}/lib
+  - export LD_LIBRARY_PATH=${PREFIX}/lib:$LD_LIBRARY_PATH
   # build flint
   - wget http://flintlib.org/flint-2.5.2.tar.gz
   - tar xf flint-2.5.2.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
   - compiler: clang
     env: CC=clang
          CXX=clang++
+         LD_LIBRARY_PATH=/usr/local/clang/lib
 env:
   MAKE="make -j2"
 install:
@@ -14,7 +15,6 @@ install:
   # set local directory and check name resolution
   - mkdir local
   - export PREFIX="/usr/local"
-  - export LD_LIBRARY_PATH="${PREFIX}/lib":$(if [[ "$CC" == "clang" ]]; then echo -n '/usr/local/clang/lib'; fi):"$LD_LIBRARY_PATH"
   # build flint
   - wget http://flintlib.org/flint-2.5.2.tar.gz
   - tar xf flint-2.5.2.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,6 @@ install:
   - ldd .libs/libeantic.so
 
 script:
-  - V=1 make check
-  - V=1 make check-valgrind
+  - V=1 make check VERBOSE=1
+  - V=1 make check-valgrind VERBOSE=1
   - V=1 make distcheck DISTCHECK_CONFIGURE_FLAGS="CFLAGS=\"-I${PREFIX}/include\" CPPFLAGS=\"-I${PREFIX}/include\" LDFLAGS=\"-L${PREFIX}/lib\""

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # set local directory and check name resolution
   - mkdir local
   - export PREFIX="/usr/local"
-  - export LD_LIBRARY_PATH=${PREFIX}/lib:$LD_LIBRARY_PATH
+  - export LD_LIBRARY_PATH="${PREFIX}/lib":$(if [[ "$CC" == "clang" ]]; then echo -n '/usr/local/clang/lib'; fi):"$LD_LIBRARY_PATH"
   # build flint
   - wget http://flintlib.org/flint-2.5.2.tar.gz
   - tar xf flint-2.5.2.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ matrix:
   - compiler: clang
     env: CC=clang
          CXX=clang++
-         LD_LIBRARY_PATH=/usr/local/clang/lib
+         LD_LIBRARY_PATH=$PREFIX/lib:/usr/local/clang/lib
 env:
+  PREFIX=/usr/local
   MAKE="make -j2"
 install:
   - sudo apt-get install libgmp-dev libmpfr-dev valgrind
   # set local directory and check name resolution
   - mkdir local
-  - export PREFIX="/usr/local"
   # build flint
   - wget http://flintlib.org/flint-2.5.2.tar.gz
   - tar xf flint-2.5.2.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,5 @@ install:
 
 script:
   - V=1 make check VERBOSE=1
-  - V=1 make check-valgrind VERBOSE=1
+  - if [ "$CC" != clang ]; then V=1 make check-valgrind VERBOSE=1; fi
   - V=1 make distcheck DISTCHECK_CONFIGURE_FLAGS="CFLAGS=\"-I${PREFIX}/include\" CPPFLAGS=\"-I${PREFIX}/include\" LDFLAGS=\"-L${PREFIX}/lib\""

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,8 +7,8 @@ AM_CFLAGS = $(OPENMP_CFLAGS)
 lib_LTLIBRARIES = libeantic.la libeanticxx.la
 
 # Linked-against libraries
-libeantic_la_LIBADD = -larb -lflint -lgmp
-libeanticxx_la_LIBADD = libeantic.la -larb -lflint -lgmpxx -lgmp
+libeantic_la_LIBADD = @LIBS@
+libeanticxx_la_LIBADD = libeantic.la -lgmpxx -lflint
 
 # Installed headers
 nobase_include_HEADERS = e-antic/e-antic.h e-antic/nf.h e-antic/nf_elem.h e-antic/renf.h e-antic/renf_elem.h e-antic/poly_extra.h e-antic/renfxx.h


### PR DESCRIPTION
This is another fix to handle -lflint-arb on Debian, follow up from #82. (Sorry for missing this earlier.)