### PR TITLE
Allowing Flint versions >= 2.5.2

### DIFF
--- a/e-antic/e-antic.h
+++ b/e-antic/e-antic.h
@@ -20,8 +20,8 @@ extern "C" {
 
 /* check flint version */
 
-#if __FLINT_RELEASE != 20502 && __FLINT_RELEASE != 20503 && __FLINT_RELEASE != 20600
-#error FLINT 2.5.2 or 2.5.3 required
+#if __FLINT_RELEASE < 20502
+#error FLINT >= 2.5.2 required
 #endif
 
 #ifdef __cplusplus

--- a/e-antic/poly_extra.h
+++ b/e-antic/poly_extra.h
@@ -262,7 +262,7 @@ void fmpz_poly_evaluate_at_one(fmpz_t res, fmpz * p, slong len)
     return _fmpz_vec_sum(res, p, len);
 }
 
-#if __FLINT_RELEASE != 20600
+#if __FLINT_RELEASE < 20600
 static __inline__
 double fmpq_get_d(const fmpq_t q)
 {
@@ -346,14 +346,14 @@ void _fmpz_poly_num_real_roots_sturm(slong * n_neg, slong * n_pos, const fmpz * 
 
 void fmpz_poly_product_roots_fmpq_vec(fmpz_poly_t poly, const fmpq * xs, slong n);
 
-#elif __FLINT_RELEASE == 20503 || __FLINT_RELEASE == 20600
+#elif __FLINT_RELEASE > 20502
 
 #define _EANTIC_FIXED_fmpq_poly_get_str_pretty _fmpq_poly_get_str_pretty
 #define EANTIC_FIXED_fmpq_poly_get_str_pretty fmpq_poly_get_str_pretty
 
 #else
 
-#error "Invalid flint release: e-antic needs flint-2.5.2, flint-2.5.3 or flint-2.6.0"
+#error "Invalid flint release: e-antic needs flint >= 2.5.2"
 
 #endif
 

--- a/e-antic/renfxx.h
+++ b/e-antic/renfxx.h
@@ -144,8 +144,8 @@ public:
     __RENFXX_construct(mpz_class&, assign_mpz_class)
     __RENFXX_construct(mpq_class&, assign_mpq_class)
     __RENFXX_construct(fmpq_poly_t, assign_fmpq_poly)
-    explicit __RENFXX_construct(std::vector<mpz_class>&, assign_mpz_vector);
-    explicit __RENFXX_construct(std::vector<mpq_class>&, assign_mpq_vector);
+    explicit __RENFXX_construct(std::vector<mpz_class>&, assign_mpz_vector)
+    explicit __RENFXX_construct(std::vector<mpq_class>&, assign_mpq_vector)
     explicit __RENFXX_construct(std::string&, assign_string)
     #undef __constructor
 
@@ -491,11 +491,11 @@ inline void renf_elem_class::assign_mpz_vector(const std::vector<mpz_class>& v)
 
     if (nf == nullptr)
         throw std::invalid_argument("renf_elem_class: can not assign from std::vector<mpz_class> if number field not set");
-    if (v.size() > nf->degree())
+    if ((long) v.size() > nf->degree())
         throw std::invalid_argument("vector too long");
 
     fmpq_poly_init(p);
-    for (slong i = 0; i < v.size(); i++)
+    for (slong i = 0; i < (long) v.size(); i++)
         fmpq_poly_set_coeff_mpz(p, i, v[i].__get_mp());
     assign_fmpq_poly(p);
     fmpq_poly_clear(p);
@@ -507,11 +507,11 @@ inline void renf_elem_class::assign_mpq_vector(const std::vector<mpq_class>& v)
 
     if (nf == nullptr)
         throw std::invalid_argument("renf_elem_class: can not assign from std::vector<mpz_class> if number field not set");
-    if (v.size() > nf->degree())
+    if ((long) v.size() > nf->degree())
         throw std::invalid_argument("vector too long");
 
     fmpq_poly_init(p);
-    for (slong i = 0; i < v.size(); i++)
+    for (slong i = 0; i < (long) v.size(); i++)
         fmpq_poly_set_coeff_mpq(p, i, v[i].__get_mp());
     assign_fmpq_poly(p);
     fmpq_poly_clear(p);

--- a/nf_elem/mul.c
+++ b/nf_elem/mul.c
@@ -127,7 +127,7 @@ void _nf_elem_mul_red(nf_elem_t a, const nf_elem_t b,
                
                _fmpz_vec_set(r, NF_ELEM_NUMREF(a), plen);
 
-#if __FLINT_RELEASE == 20600
+#if __FLINT_RELEASE >= 20600
                _fmpz_poly_divrem(q, NF_ELEM_NUMREF(a), r, plen, 
                   fmpq_poly_numref(nf->pol), len, 0);
 #else

--- a/nf_elem/reduce.c
+++ b/nf_elem/reduce.c
@@ -80,7 +80,7 @@ void _nf_elem_reduce(nf_elem_t a, const nf_t nf)
                
                _fmpz_vec_set(r, NF_ELEM_NUMREF(a), plen);
 
-#if __FLINT_RELEASE == 20600
+#if __FLINT_RELEASE >= 20600
                _fmpz_poly_divrem(q, NF_ELEM_NUMREF(a), r, plen, 
                   fmpq_poly_numref(nf->pol), len, 0);
 #else


### PR DESCRIPTION
With the changes e-antic should accept all Flint versions from 2.5.2 on. The changes have been tested in the Normaliz Travis builds with Flint 2.6.0 (Linux) and 2.6.1 (Mac).