### PR TITLE
gitignore compile_flags.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ aclocal.m4
 *.swp
 tmp/
 compile_commands.json
+compile_flags.txt
 .ccls-cache/
 
 # Test binaries (but not their sources!)


### PR DESCRIPTION
this file is read e.g. by clangd which some editors use.