### PR TITLE
Compress cereal output

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -243,7 +243,7 @@ renfxx_test_t_get_str_SOURCES = renfxx/test/t-get_str.cpp
 renfxx_test_t_get_str_LDADD = libeanticxx.la libeantic.la
 renfxx_test_t_stream_SOURCES = renfxx/test/main.cpp renfxx/test/t-stream.cpp
 renfxx_test_t_stream_LDADD = libeanticxx.la libeantic.la
-renfxx_test_t_cereal_SOURCES = renfxx/test/t-cereal.cpp
+renfxx_test_t_cereal_SOURCES = renfxx/test/main.cpp renfxx/test/t-cereal.cpp
 renfxx_test_t_cereal_LDADD = libeanticxx.la libeantic.la
 renfxx_test_t_cereal_CPPFLAGS = -isystem $(srcdir)/renfxx/test/external/cereal/include
 

--- a/e-antic/renfxx_cereal.h
+++ b/e-antic/renfxx_cereal.h
@@ -91,8 +91,8 @@ void save(Archive & archive, const renf_elem_class & self, std::uint32_t)
 {
     archive(
         cereal::make_nvp("parent", self.parent().shared_from_this()),
-        cereal::make_nvp("value", boost::lexical_cast<std::string>(self)),
-        cereal::make_nvp("double", static_cast<double>(self)));
+        cereal::make_nvp("value", self.to_string(EANTIC_STR_ALG))
+    );
 }
 
 template <class Archive>
@@ -102,15 +102,12 @@ void load(Archive & archive, renf_elem_class & self, std::uint32_t version)
 
     std::shared_ptr<const renf_class> nf;
     std::string serialized_element;
-    double _;
-    
-    archive(nf, serialized_element, _);
 
-    std::stringstream ss(serialized_element);
+    archive(nf, serialized_element);
+
+    std::stringstream ss("(" + serialized_element + ")");
     if (nf)
-    {
         nf->set_pword(ss);
-    }
     ss >> self;
 }
 

--- a/e-antic/renfxx_cereal.h
+++ b/e-antic/renfxx_cereal.h
@@ -29,26 +29,17 @@ void save(Archive & archive, const std::shared_ptr<const renf_class> & self)
         // This is the first time cereal sees this renf_class, so we actually
         // store it. Future copies only need the id to resolve to a shared_ptr
         // to the same renf_class.
-        bool rational = !static_cast<bool>(self);
-        archive(cereal::make_nvp("rational", rational));
-        if (rational)
-        {
-            return;
-        }
-        else
-        {
-            char * emb = arb_get_str(self->renf_t()->emb, arf_bits(arb_midref(self->renf_t()->emb)), 0);
-            char * pol = fmpq_poly_get_str_pretty(self->renf_t()->nf->pol, self->gen_name().c_str());
+        char * emb = arb_get_str(self->renf_t()->emb, arf_bits(arb_midref(self->renf_t()->emb)), 0);
+        char * pol = fmpq_poly_get_str_pretty(self->renf_t()->nf->pol, self->gen_name().c_str());
 
-            archive(
-                cereal::make_nvp("name", self->gen_name()),
-                cereal::make_nvp("embedding", std::string(emb)),
-                cereal::make_nvp("minpoly", std::string(pol)),
-                cereal::make_nvp("precision", self->renf_t()->prec));
+        archive(
+            cereal::make_nvp("name", self->gen_name()),
+            cereal::make_nvp("embedding", std::string(emb)),
+            cereal::make_nvp("minpoly", std::string(pol)),
+            cereal::make_nvp("precision", self->renf_t()->prec));
 
-            flint_free(pol);
-            flint_free(emb);
-        }
+        flint_free(pol);
+        flint_free(emb);
     }
 }
 
@@ -66,21 +57,12 @@ void load(Archive & archive, std::shared_ptr<const renf_class> & self)
 
     if ( id & static_cast<unsigned int>(cereal::detail::msb_32bit) )
     {
-        bool rational;
-        archive(rational);
-        if (rational)
-        {
-            self = nullptr;
-        }
-        else
-        {
-            std::string name, emb, pol;
-            slong prec;
-            
-            archive(name, emb, pol, prec);
+        std::string name, emb, pol;
+        slong prec;
 
-            self = renf_class::make(pol, name, emb, prec);
-        }
+        archive(name, emb, pol, prec);
+
+        self = renf_class::make(pol, name, emb, prec);
 
         const auto reinterpret_ptr_cast = [](const auto& ptr) noexcept
         {

--- a/renfxx/test/t-cereal.cpp
+++ b/renfxx/test/t-cereal.cpp
@@ -13,57 +13,52 @@
 #include <cereal/archives/json.hpp>
 #include <cereal/types/vector.hpp>
 
-#include "e-antic/renfxx.h"
-#include "e-antic/renfxx_cereal.h"
+#include "../../e-antic/renfxx.h"
+#include "../../e-antic/renfxx_cereal.h"
+
+#include "../../renf/test/rand_generator.hpp"
+#include "renf_class_generator.hpp"
+#include "renf_elem_class_generator.hpp"
 
 using namespace eantic;
-using cereal::JSONOutputArchive;
-using cereal::JSONInputArchive;
 
 template <typename T>
 T test_serialization(const T& x)
 {
-    std::stringstream s;
+    CAPTURE(x);
 
+    std::stringstream s;
     {
-        JSONOutputArchive archive(s);
+        ::cereal::JSONOutputArchive archive(s);
         archive(x);
     }
 
+    CAPTURE(s.str());
+
     T y;
     {
-        JSONInputArchive archive(s);
+        ::cereal::JSONInputArchive archive(s);
         archive(y);
     }
 
-    if (x != y)
-    {
-        throw std::runtime_error("deserialization failed to reconstruct element, the original value had serialized to " + s.str());
-    }
+    CAPTURE(y);
+
+    REQUIRE(x == y);
 
     return y;
 }
 
-int main(void)
+std::shared_ptr<const renf_class> K = nullptr;
+
+TEST_CASE("Serialize and deserialize elements", "[renf_class][renf_elem_class]")
 {
-    auto K1 = renf_class::make("A^3 - 2", "A", "1.25 +/- 0.1");
-    auto K2 = renf_class::make("2*abc^4 - 5*abc + 1", "abc", "0.2 +/- 0.1");
-    const renf_elem_class g1 = K1->gen();
-    const renf_elem_class g2 = K2->gen();
+    flint_rand_t& state = GENERATE(rands());
+    K = GENERATE_REF(renf_classs(state));
+    auto a = GENERATE_REF(renf_elem_classs(state, K, 4));
+    auto b = GENERATE_REF(renf_elem_classs(state, K, 4));
 
-    test_serialization(renf_elem_class(mpz_class("0")));
-    test_serialization(renf_elem_class(mpq_class("2/3")));
-    test_serialization(K1->gen());
-    test_serialization(K2->gen());
-    test_serialization(renf_elem_class(K1));
-    test_serialization(renf_elem_class(K2));
-    test_serialization(renf_elem_class(K1, "3*A^2-1"));
+    CAPTURE(*K);
 
-    auto items = test_serialization(std::vector<renf_elem_class>{g1, K1->one()});
-    if (&items[0].parent() != &items[1].parent())
-    {
-        throw std::runtime_error("parents of elements were not deduplicated");
-    }
-
-    return 0;
+    test_serialization(a);
+    test_serialization(std::vector<renf_elem_class>{a, a, b});
 }

--- a/renfxx/test/t-cereal.cpp
+++ b/renfxx/test/t-cereal.cpp
@@ -48,7 +48,7 @@ T test_serialization(const T& x)
     return y;
 }
 
-std::shared_ptr<const renf_class> K = nullptr;
+static std::shared_ptr<const renf_class> K = nullptr;
 
 TEST_CASE("Serialize and deserialize elements", "[renf_class][renf_elem_class]")
 {

--- a/renfxx/test/t-stream.cpp
+++ b/renfxx/test/t-stream.cpp
@@ -55,10 +55,12 @@ TEST_CASE("Converting fields to strings", "[renf_class][operator<<]")
     }
 }
 
+static std::shared_ptr<const renf_class> K = nullptr;
+
 TEST_CASE("Writing and reading elements from streams", "[renf_elem_class][operator<<][operator>>]")
 {
     flint_rand_t& state = GENERATE(rands());
-    auto K = GENERATE_REF(renf_classs(state));
+    K = GENERATE_REF(renf_classs(state));
     auto a = GENERATE_REF(renf_elem_classs(state, K));
 
     CAPTURE(a);


### PR DESCRIPTION
also improves testing and removes some fmpq leftovers.