### PR TITLE
Add Benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda create -q -n e-antic-build -c conda-forge python=$TRAVIS_PYTHON_VERSION antic libflint arb valgrind autoconf automake cxx-compiler c-compiler libtool boost-cpp $PACKAGES
+  - conda create -q -n e-antic-build -c conda-forge python=$TRAVIS_PYTHON_VERSION antic libflint arb valgrind autoconf automake cxx-compiler c-compiler libtool boost-cpp benchmark $PACKAGES
   - conda activate e-antic-build
   - export CC=${_CC:-$CC}
   - export CXX=${_CXX:-$CXX}

--- a/Makefile.am
+++ b/Makefile.am
@@ -254,7 +254,7 @@ if HAVE_BENCHMARK
 
 noinst_PROGRAMS += renfxx/benchmark/benchmark
 
-renfxx_benchmark_benchmark_SOURCES = renfxx/benchmark/main.cpp
+renfxx_benchmark_benchmark_SOURCES = renfxx/benchmark/main.cpp renfxx/benchmark/b-constructor.cpp
 
 renfxx_benchmark_benchmark_LDADD = $(builddir)/libeanticxx.la $(builddir)/libeantic.la
 # Include Google's libbenchmark and dependent libraries

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ AM_CPPFLAGS = -I.
 
 # Initialize variables, to be filled below
 noinst_HEADERS =
+noinst_PROGRAMS =
 libeantic_la_SOURCES =
 check_PROGRAMS =
 dist_doc_DATA =
@@ -247,5 +248,16 @@ renfxx_test_t_cereal_SOURCES = renfxx/test/main.cpp renfxx/test/t-cereal.cpp
 renfxx_test_t_cereal_LDADD = libeanticxx.la libeantic.la
 renfxx_test_t_cereal_CPPFLAGS = -isystem $(srcdir)/renfxx/test/external/cereal/include
 
-# test suite
 TESTS = $(check_PROGRAMS)
+
+if HAVE_BENCHMARK
+
+noinst_PROGRAMS += renfxx/benchmark/benchmark
+
+renfxx_benchmark_benchmark_SOURCES = renfxx/benchmark/main.cpp
+
+renfxx_benchmark_benchmark_LDADD = $(builddir)/libeanticxx.la $(builddir)/libeantic.la
+# Include Google's libbenchmark and dependent libraries
+renfxx_benchmark_benchmark_LDFLAGS = -lbenchmark -lrt -lpthread
+
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,17 @@ AC_LANG_PUSH([C++])
 AX_CXX_COMPILE_STDCXX(14)
 AC_CHECK_HEADER(gmpxx.h, , [AC_MSG_ERROR([gmpxx header not found (GMP needs to be compiled with c++ support (--enable-cxx))])])
 AC_CHECK_HEADERS(boost/lexical_cast.hpp, , [AC_MSG_ERROR([boost headers not found])])
+
+dnl Our benchmarks use Google's C++ benchmark library.
+dnl We fail if they cannot be found but let the user disable it explicitly.
+AC_ARG_WITH([benchmark], AS_HELP_STRING([--without-benchmark], [Do not build C++ benchmarks that require google/benchmark]))
+AS_IF([test "x$with_benchmark" != "xno"],
+      [
+       with_benchmark=yes
+       AC_CHECK_HEADERS([benchmark/benchmark.h], , AC_MSG_ERROR([benchmark headers not found; run --without-benchmark to disable building of benchmark/]))
+      ], [])
+AM_CONDITIONAL([HAVE_BENCHMARK], [test "x$with_benchmark" = "xyes"])
+
 AC_LANG_POP([C++])
 
 AC_OUTPUT

--- a/renfxx/benchmark/b-constructor.cpp
+++ b/renfxx/benchmark/b-constructor.cpp
@@ -1,0 +1,33 @@
+/*
+    Copyright (C) 2020 Vincent Delecroix
+    Copyright (C) 2020 Julian Rüth
+
+    This file is part of e-antic
+
+    e-antic is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3.0 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include <benchmark/benchmark.h>
+
+#include "../../e-antic/renfxx.h"
+
+using benchmark::DoNotOptimize;
+using benchmark::State;
+
+namespace eantic {
+namespace benchmark {
+
+void ConstructTrivialField(State& state)
+{
+    for (auto _ : state)
+    {
+        DoNotOptimize(renf_class::make());
+    }
+}
+BENCHMARK(ConstructTrivialField);
+
+}
+}

--- a/renfxx/benchmark/b-constructor.cpp
+++ b/renfxx/benchmark/b-constructor.cpp
@@ -20,7 +20,7 @@ using benchmark::State;
 namespace eantic {
 namespace benchmark {
 
-void ConstructTrivialField(State& state)
+static void ConstructTrivialField(State& state)
 {
     for (auto _ : state)
     {

--- a/renfxx/benchmark/main.cpp
+++ b/renfxx/benchmark/main.cpp
@@ -1,0 +1,15 @@
+/*
+    Copyright (C) 2020 Vincent Delecroix
+    Copyright (C) 2020 Julian Rüth
+
+    This file is part of e-antic
+
+    e-antic is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3.0 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include <benchmark/benchmark.h>
+
+BENCHMARK_MAIN();

--- a/renfxx/renf_class.cpp
+++ b/renfxx/renf_class.cpp
@@ -1,6 +1,6 @@
 /*
     Copyright (C) 2018 Vincent Delecroix
-    Copyright (C) 2019 Julian Rüth
+    Copyright (C) 2019-2020 Julian Rüth
 
     This file is part of e-antic
 
@@ -88,7 +88,8 @@ renf_class::renf_class(const std::string & minpoly, const std::string & gen, con
 
 std::shared_ptr<const renf_class> renf_class::make() noexcept
 {
-    return factory.get(Key(new renf_class()), [&]() { return new renf_class; });
+    static auto trivial = factory.get(Key(new renf_class()), [&]() { return new renf_class; });
+    return trivial;
 }
 
 std::shared_ptr<const renf_class> renf_class::make(const ::renf_t k, const std::string & gen_name) noexcept


### PR DESCRIPTION
fixes #115

The benchmarks do not run in the CI yet (in particular they are not recorded anywhere.) I guess I would eventually like to use the same setup that I use for the flatsurf stack here. But let's see about that in a separate PR.

I added one sample benchmark (which means that flow decomposition will now only use 65% of the time…)