### PR TITLE
Release with rever

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ t-*
 
 # distributions
 /e-antic*.tar.gz
+/rever

--- a/NEWS
+++ b/NEWS
@@ -1,115 +1,16 @@
-This file is part of the e-ANTIC library
+==================
+e-antic Change Log
+==================
 
-The e-ANTIC Library is free software; you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at your
-option) any later version.
+.. current developments
 
-The e-ANTIC Library is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-License for more details.
+v0.1
+====
 
-You should have received a copy of the GNU Lesser General Public License
-along with the e-ANTIC Library; see the file COPYING.LESSER.  If not, see
-http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc.,
-51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+**Added:**
 
-##############################################################################
+* real roots isolation and refinement (poly_extra.h)
+* renf structure (renf.h)
+* renf_elem structures (renf_elem.h)
+* C++ interface (renfxx.h)
 
-Release 0.1
-===========
-- real roots isolation and refinement (poly_extra.h)
-- renf structure (renf.h)
-- renf_elem structures (renf_elem.h)
-- C++ interface (renfxx.h)
-
-Release 1.0
-===========
-
-New C function
---------------
-- ` renf_elem_swap(renf_elem_t, renf_elem_t)`
-
-Multithread support
--------------------
-- e-antic had claimed to be thread safe via an open MP pragma (in the number
-  field refinement). In some cases, there was a problem with thread-safety. We
-  now require users to explicitly mark multithreaded sections by forbidding
-  mutations to a renf, see `renf_set_immutable`. As a result, there are some
-  operations that cannot be done anymore in a multi-threaded environment but
-  they now fail properly (instead of leading to random crashes.)
-
-Breaking Changes to the C++ Interface
--------------------------------------
-- `e-antic/renfxx.h` requires C++17.
-- All classes are now declared in the namespace `eantic`.
-- The semantics of `operator =` have changed. In e-antic 0.1 the following
-  would create the unit in the field K.
-  ```
-  renf_elem_class x(K);
-  x = 1;
-  ```
-  Now the above statement makes x a rational number. More generally, an
-  assignment resets the number field so that after `x = y` the condition
-  `x.nf == renf_elem_class(y).nf` holds. To mimic the old behavior you need
-  to rewrite the above as
-  ```
-  renf_elem_class x(K);
-  x = renf_elem_class(K, 1);
-  ```
-- `renf_class` is now hidden behind a factory to get shared_ptr semantics
-  everywhere. Create a `renf_class` by calling `renf_class::make(…)`. This
-	returns a smart pointer, so you might have to replace some `.` with `->`.
-- The change of semantics in assignment also affects reading from streams (in
-  order to create `renf_elem_class`). Before the following would parse an element
-  into a number field:
-  ```
-  renf_elem_class x(K);
-  in >> x;
-  ```
-  Now this only works if the stream contains a rational number. (Otherwise an
-  exception is raised.) As `in >> x` also resets `x.nf`. The above code should
-  be replaced with:
-  ```
-  renf_elem_class x;
-  K.set_pword(in);
-  in >> x;
-  ```
-- `renf_elem_class(string&)` has been removed. If you want to parse a rational
-  number, use `renf_elem_class(mpq_class(string))`. If you want to parse into a
-  number field, use `renf_elem_class(renf_class&, string&)`.
-- `renf_elem_class::operator=(string&)` has been removed. If you want to parse
-  a rational into an element, use `x = mpq_class(string)`. If you want to parse
-  into a number field, use `x = renf_elem_class(x.parent(), string)`.
-- `renf_elem_class(vector<...>)` have been removed as it would have thrown an
-  exception always anyway.
-- `renf_elem_class::operator=(vector<...>)` have been removed due to the change
-  of semantics of `=`. If `x` is not a rational you get the same behaviour as
-  before with `x = renf_elem_class(x.parent(), {1, 2, 3})`.
-- `renf_class::xalloc()` has been removed and replaced by an implementation
-  detail.
-- `string renf_class::gen_name` is now a method so it needs to be called.
-- Many operations that threw an exception before when domains were mixed, now
-  abort program execution (typically through a call to `assert()`.) You can
-  identify these operations by their `noexcept` modifier.
-- `renf_class.operator==` now also checks that the generator name is the same.
-  Similarly, `renf_class.operator=` now also resets the generator name.
-
-
-Non-Breaking Changes to the C++ Interface
------------------------------------------
-- There is now `e-antic/renfxx_fwd.h` if you only need forward declarations of
-  `renf_class` and `renf_elem_class`.
-- Some methods have been deprecated and might be removed in a future release,
-  mostly to make the interface more consistent. The deprecation warnings give
-  hints which methods to use instead.
-- `renf_elem_class` can now be created from signed and unsigned long long.
-- `renf_elem_class` can now be created from vectors of primitive integers, e.g.,
-  ```
-  renf_elem_class x(K, {1, 2, 3}); // = 3*x^2 + 2*x + 1
-  ```
-  where before the entries of the vector had to be `mpz_class`.
-- Move semantics `&&` have been added to `renf_elem_class`.
-- There is now support for serialization with cereal. See t-cereal.cpp for
-  examples on how to use it.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ E-ANTIC is a C/C++ library to deal with real embedded number fields built on
 top of ANTIC (https://github.com/wbhart/antic). Its aim is to have as fast
 as possible exact arithmetic operations and comparisons.
 
-Source tarballs can be downloaded at http://www.labri.fr/perso/vdelecro/e-antic.
+Source tarballs can be downloaded at https://github.com/videlec/e-antic/releases.
 
 The dependencies are:
 
@@ -34,4 +34,3 @@ the configure script
     $ ./configure CPPFLAGS=-I/my/path/include LDFLAGS=-L/my/path/lib
 
 For more detailed but generic instructions please refer to the INSTALL file.
-

--- a/news/100.rst
+++ b/news/100.rst
@@ -1,0 +1,88 @@
+**Added:**
+
+* ` renf_elem_swap(renf_elem_t, renf_elem_t)`
+* There is now `e-antic/renfxx_fwd.h` if you only need forward declarations of
+  `renf_class` and `renf_elem_class`.
+* `renf_elem_class` can now be created from signed and unsigned long long.
+* `renf_elem_class` can now be created from vectors of primitive integers, e.g.,
+  ```
+  renf_elem_class x(K, {1, 2, 3}); // = 3*x^2 + 2*x + 1
+  ```
+  where before the entries of the vector had to be `mpz_class`.
+* Move semantics `&&` have been added to `renf_elem_class`.
+* There is now support for serialization with cereal. See t-cereal.cpp for
+  examples on how to use it.
+
+**Fixed:**
+
+* e-antic had claimed to be thread safe via an open MP pragma (in the number
+  field refinement). In some cases, there was a problem with thread-safety. We
+  now require users to explicitly mark multithreaded sections by forbidding
+  mutations to a renf, see `renf_set_immutable`. As a result, there are some
+  operations that cannot be done anymore in a multi-threaded environment but
+  they now fail properly (instead of leading to random crashes.)
+
+**Changed:**
+
+* `e-antic/renfxx.h` now requires C++17.
+* All classes are now declared in the namespace `eantic`.
+* The semantics of `operator =` have changed. In e-antic 0.1 the following
+  would create the unit in the field K.
+  ```
+  renf_elem_class x(K);
+  x = 1;
+  ```
+  Now the above statement makes x a rational number. More generally, an
+  assignment resets the number field so that after `x = y` the condition
+  `x.nf == renf_elem_class(y).nf` holds. To mimic the old behavior you need
+  to rewrite the above as
+  ```
+  renf_elem_class x(K);
+  x = renf_elem_class(K, 1);
+  ```
+* `renf_class` is now hidden behind a factory to get shared_ptr semantics
+  everywhere. Create a `renf_class` by calling `renf_class::make(…)`. This
+	returns a smart pointer, so you might have to replace some `.` with `->`.
+* The change of semantics in assignment also affects reading from streams (in
+  order to create `renf_elem_class`). Before the following would parse an element
+  into a number field:
+  ```
+  renf_elem_class x(K);
+  in >> x;
+  ```
+  Now this only works if the stream contains a rational number. (Otherwise an
+  exception is raised.) As `in >> x` also resets `x.nf`. The above code should
+  be replaced with:
+  ```
+  renf_elem_class x;
+  K.set_pword(in);
+  in >> x;
+  ```
+* `string renf_class::gen_name` is now a method so it needs to be called.
+* Many operations that threw an exception before when domains were mixed, now
+  abort program execution (typically through a call to `assert()`.) You can
+  identify these operations by their `noexcept` modifier.
+* `renf_class.operator==` now also checks that the generator name is the same.
+  Similarly, `renf_class.operator=` now also resets the generator name.
+
+**Deprecated:**
+
+* Some methods have been deprecated and might be removed in a future release,
+  mostly to make the interface more consistent. The deprecation warnings give
+  hints which methods to use instead.
+
+**Removed:**
+
+* `renf_elem_class(string&)` has been removed. If you want to parse a rational
+  number, use `renf_elem_class(mpq_class(string))`. If you want to parse into a
+  number field, use `renf_elem_class(renf_class&, string&)`.
+* `renf_elem_class::operator=(string&)` has been removed. If you want to parse
+  a rational into an element, use `x = mpq_class(string)`. If you want to parse
+  into a number field, use `x = renf_elem_class(x.parent(), string)`.
+* `renf_elem_class(vector<...>)` have been removed as it would have thrown an
+  exception always anyway.
+* `renf_elem_class::operator=(vector<...>)` have been removed due to the change
+  of semantics of `=`. If `x` is not a rational you get the same behaviour as
+  before with `x = renf_elem_class(x.parent(), {1, 2, 3})`.
+* `renf_class::xalloc()` has been removed and replaced by an implementation
+  detail.

--- a/news/TEMPLATE.rst
+++ b/news/TEMPLATE.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/rever.rst
+++ b/news/rever.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* the release process has been automated with [rever](https://regro.github.io/rever-docs/)

--- a/rever.xsh
+++ b/rever.xsh
@@ -1,0 +1,74 @@
+######################################################################
+#  This file is part of e-antic.
+#
+#        Copyright (C) 2020 Julian Rüth
+#
+#  e-antic is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  e-antic is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with e-antic. If not, see <https://www.gnu.org/licenses/>.
+#####################################################################
+
+import sys
+from packaging import version
+
+from rever.activity import activity
+
+try:
+  input("Are you sure you are on the master branch which is identical to origin/master and the only pending changes are a version_info bump in configure.ac? [ENTER]")
+except KeyboardInterrupt:
+  sys.exit(1)
+
+@activity
+def dist():
+    r"""
+    Run make dist and collect the resulting tarball.
+    """
+    from tempfile import TemporaryDirectory
+    from xonsh.dirstack import DIRSTACK
+    with TemporaryDirectory() as tmp:
+        ./bootstrap.sh
+        pushd @(tmp)
+        @(DIRSTACK[-1])/configure
+        make dist
+        mv *.tar.gz @(DIRSTACK[-1])
+        popd
+    return True
+
+$PROJECT = 'e-antic'
+
+$ACTIVITIES = [
+    'version_bump',
+    'changelog',
+    'dist',
+    'tag',
+    'push_tag',
+    'ghrelease',
+]
+
+MAJOR, MINOR, PATCH = version.parse($VERSION).release
+
+$VERSION_BUMP_PATTERNS = [
+    ('configure.ac', r'AC_INIT', r'AC_INIT([e-antic], [$VERSION], [vincent.delecroix@math.cnrs.fr])'),
+    ('e-antic/e-antic.h.in', r'#define E_ANTIC_VERSION ', r'#define E_ANTIC_VERSION "$VERSION"'),
+    ('e-antic/e-antic.h.in', r'#define E_ANTIC_VERSION_MAJOR', rf'#define E_ANTIC_VERSION_MAJOR {MAJOR}'),
+    ('e-antic/e-antic.h.in', r'#define E_ANTIC_VERSION_MINOR', rf'#define E_ANTIC_VERSION_MINOR {MINOR}'),
+    ('e-antic/e-antic.h.in', r'#define E_ANTIC_VERSION_PATCHLEVEL', rf'#define E_ANTIC_VERSION_PATCHLEVEL {PATCH}'),
+]
+
+$CHANGELOG_FILENAME = 'NEWS'
+$CHANGELOG_TEMPLATE = 'TEMPLATE.rst'
+$PUSH_TAG_REMOTE = 'git@github.com:videlec/e-antic.git'
+
+$GITHUB_ORG = 'videlec'
+$GITHUB_REPO = 'e-antic'
+
+$GHRELEASE_ASSETS = ['e-antic-' + $VERSION + '.tar.gz']


### PR DESCRIPTION
fixes #123

Once this has been merged, we should be able to release a new version with:
```sh
# Go to master as it is upstream, e.g.,
git fetch origin
git checkout master
git reset --hard origin/master
# Release with rever
rever 1.0.0-rc2
```