### PR TITLE
Drop noexcept qualifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ t-*
 
 # distributions
 /e-antic*.tar.gz
+/rever

--- a/NEWS
+++ b/NEWS
@@ -1,115 +1,16 @@
-This file is part of the e-ANTIC library
+==================
+e-antic Change Log
+==================
 
-The e-ANTIC Library is free software; you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation; either version 3 of the License, or (at your
-option) any later version.
+.. current developments
 
-The e-ANTIC Library is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
-License for more details.
+v0.1
+====
 
-You should have received a copy of the GNU Lesser General Public License
-along with the e-ANTIC Library; see the file COPYING.LESSER.  If not, see
-http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc.,
-51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+**Added:**
 
-##############################################################################
+* real roots isolation and refinement (poly_extra.h)
+* renf structure (renf.h)
+* renf_elem structures (renf_elem.h)
+* C++ interface (renfxx.h)
 
-Release 0.1
-===========
-- real roots isolation and refinement (poly_extra.h)
-- renf structure (renf.h)
-- renf_elem structures (renf_elem.h)
-- C++ interface (renfxx.h)
-
-Release 1.0
-===========
-
-New C function
---------------
-- ` renf_elem_swap(renf_elem_t, renf_elem_t)`
-
-Multithread support
--------------------
-- e-antic had claimed to be thread safe via an open MP pragma (in the number
-  field refinement). In some cases, there was a problem with thread-safety. We
-  now require users to explicitly mark multithreaded sections by forbidding
-  mutations to a renf, see `renf_set_immutable`. As a result, there are some
-  operations that cannot be done anymore in a multi-threaded environment but
-  they now fail properly (instead of leading to random crashes.)
-
-Breaking Changes to the C++ Interface
--------------------------------------
-- `e-antic/renfxx.h` requires C++17.
-- All classes are now declared in the namespace `eantic`.
-- The semantics of `operator =` have changed. In e-antic 0.1 the following
-  would create the unit in the field K.
-  ```
-  renf_elem_class x(K);
-  x = 1;
-  ```
-  Now the above statement makes x a rational number. More generally, an
-  assignment resets the number field so that after `x = y` the condition
-  `x.nf == renf_elem_class(y).nf` holds. To mimic the old behavior you need
-  to rewrite the above as
-  ```
-  renf_elem_class x(K);
-  x = renf_elem_class(K, 1);
-  ```
-- `renf_class` is now hidden behind a factory to get shared_ptr semantics
-  everywhere. Create a `renf_class` by calling `renf_class::make(…)`. This
-	returns a smart pointer, so you might have to replace some `.` with `->`.
-- The change of semantics in assignment also affects reading from streams (in
-  order to create `renf_elem_class`). Before the following would parse an element
-  into a number field:
-  ```
-  renf_elem_class x(K);
-  in >> x;
-  ```
-  Now this only works if the stream contains a rational number. (Otherwise an
-  exception is raised.) As `in >> x` also resets `x.nf`. The above code should
-  be replaced with:
-  ```
-  renf_elem_class x;
-  K.set_pword(in);
-  in >> x;
-  ```
-- `renf_elem_class(string&)` has been removed. If you want to parse a rational
-  number, use `renf_elem_class(mpq_class(string))`. If you want to parse into a
-  number field, use `renf_elem_class(renf_class&, string&)`.
-- `renf_elem_class::operator=(string&)` has been removed. If you want to parse
-  a rational into an element, use `x = mpq_class(string)`. If you want to parse
-  into a number field, use `x = renf_elem_class(x.parent(), string)`.
-- `renf_elem_class(vector<...>)` have been removed as it would have thrown an
-  exception always anyway.
-- `renf_elem_class::operator=(vector<...>)` have been removed due to the change
-  of semantics of `=`. If `x` is not a rational you get the same behaviour as
-  before with `x = renf_elem_class(x.parent(), {1, 2, 3})`.
-- `renf_class::xalloc()` has been removed and replaced by an implementation
-  detail.
-- `string renf_class::gen_name` is now a method so it needs to be called.
-- Many operations that threw an exception before when domains were mixed, now
-  abort program execution (typically through a call to `assert()`.) You can
-  identify these operations by their `noexcept` modifier.
-- `renf_class.operator==` now also checks that the generator name is the same.
-  Similarly, `renf_class.operator=` now also resets the generator name.
-
-
-Non-Breaking Changes to the C++ Interface
------------------------------------------
-- There is now `e-antic/renfxx_fwd.h` if you only need forward declarations of
-  `renf_class` and `renf_elem_class`.
-- Some methods have been deprecated and might be removed in a future release,
-  mostly to make the interface more consistent. The deprecation warnings give
-  hints which methods to use instead.
-- `renf_elem_class` can now be created from signed and unsigned long long.
-- `renf_elem_class` can now be created from vectors of primitive integers, e.g.,
-  ```
-  renf_elem_class x(K, {1, 2, 3}); // = 3*x^2 + 2*x + 1
-  ```
-  where before the entries of the vector had to be `mpz_class`.
-- Move semantics `&&` have been added to `renf_elem_class`.
-- There is now support for serialization with cereal. See t-cereal.cpp for
-  examples on how to use it.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ E-ANTIC is a C/C++ library to deal with real embedded number fields built on
 top of ANTIC (https://github.com/wbhart/antic). Its aim is to have as fast
 as possible exact arithmetic operations and comparisons.
 
-Source tarballs can be downloaded at http://www.labri.fr/perso/vdelecro/e-antic.
+Source tarballs can be downloaded at https://github.com/videlec/e-antic/releases.
 
 The dependencies are:
 
@@ -34,4 +34,3 @@ the configure script
     $ ./configure CPPFLAGS=-I/my/path/include LDFLAGS=-L/my/path/lib
 
 For more detailed but generic instructions please refer to the INSTALL file.
-

--- a/e-antic/renfxx.h
+++ b/e-antic/renfxx.h
@@ -35,14 +35,14 @@ namespace eantic {
 // This class provides C++ memory management for the underlying renf_t.
 class renf_class : public std::enable_shared_from_this<renf_class>, boost::equality_comparable<renf_class> {
     // The trivial number field adjoining a root of (x - 1) to the rationals
-    renf_class() noexcept;
-    renf_class(const ::renf_t, const std::string &) noexcept;
+    renf_class();
+    renf_class(const ::renf_t, const std::string &);
     renf_class(const std::string &, const std::string &, const std::string &, const slong);
 
 public:
     // The trivial number field adjoining a root of (x - 1) to the rationals
-    static std::shared_ptr<const renf_class> make() noexcept;
-    static std::shared_ptr<const renf_class> make(const ::renf_t, const std::string & gen = "a") noexcept;
+    static std::shared_ptr<const renf_class> make();
+    static std::shared_ptr<const renf_class> make(const ::renf_t, const std::string & gen = "a");
     static std::shared_ptr<const renf_class> make(const std::string & minpoly, const std::string & gen, const std::string &emb, const slong prec = 64);
 
     ~renf_class() noexcept;
@@ -51,32 +51,32 @@ public:
     // an embedded number field.
     renf_class & operator=(const renf_class &) = delete;
 
-    slong degree() const noexcept;
+    slong degree() const;
 
     // standard elements
-    renf_elem_class zero() const noexcept;
-    renf_elem_class one() const noexcept;
-    renf_elem_class gen() const noexcept;
+    renf_elem_class zero() const;
+    renf_elem_class one() const;
+    renf_elem_class gen() const;
 
-    bool operator==(const renf_class &) const noexcept;
+    bool operator==(const renf_class &) const;
 
-    const std::string & gen_name() const noexcept { return name; }
+    const std::string & gen_name() const { return name; }
 
     // Prepare an input stream to read elements living in this number field
     // from it.
     [[deprecated("use renfxx_cereal.h instead.")]]
-    std::istream & set_pword(std::istream &) const noexcept;
+    std::istream & set_pword(std::istream &) const;
 
-    std::string to_string() const noexcept;
+    std::string to_string() const;
     friend std::ostream & operator<<(std::ostream &, const renf_class &);
 
     // Raw access to the underlying renf_t; we do not return a const renf_t
     // since calls in the C API might need to modify it (e.g., to refine the
     // stored embedding) even though they are morally const.
-    ::renf_t & renf_t() const noexcept { return nf; }
+    ::renf_t & renf_t() const { return nf; }
 
-    [[deprecated("Use renf_t() instead.")]] renf * get_renf() const noexcept { return nf; }
-    [[deprecated("Use set_pword() instead.")]] std::istream & set_istream(std::istream &) const noexcept;
+    [[deprecated("Use renf_t() instead.")]] renf * get_renf() const { return nf; }
+    [[deprecated("Use set_pword() instead.")]] std::istream & set_istream(std::istream &) const;
 
 private:
     // The name of the generator
@@ -101,179 +101,179 @@ class renf_elem_class : boost::ordered_field_operators<renf_elem_class>,
 public:
     // The zero element of the rationals
     renf_elem_class() noexcept;
-    renf_elem_class(const renf_elem_class &) noexcept;
+    renf_elem_class(const renf_elem_class &);
     renf_elem_class(renf_elem_class &&) noexcept;
-    renf_elem_class(int) noexcept;
-    renf_elem_class(unsigned int) noexcept;
-    renf_elem_class(long) noexcept;
-    renf_elem_class(unsigned long) noexcept;
-    renf_elem_class(long long) noexcept;
-    renf_elem_class(unsigned long long) noexcept;
-    renf_elem_class(const mpz_class &) noexcept;
-    renf_elem_class(const mpq_class &) noexcept;
-    renf_elem_class(const fmpq_t) noexcept;
+    renf_elem_class(int);
+    renf_elem_class(unsigned int);
+    renf_elem_class(long);
+    renf_elem_class(unsigned long);
+    renf_elem_class(long long);
+    renf_elem_class(unsigned long long);
+    renf_elem_class(const mpz_class &);
+    renf_elem_class(const mpq_class &);
+    renf_elem_class(const fmpq_t);
     // The zero element in k; note that all overloads that take the field as a
     // parameter hold a non-owning reference to the field, i.e., the element is
     // only valid while that reference is.
-    explicit renf_elem_class(std::shared_ptr<const renf_class> k) noexcept;
+    explicit renf_elem_class(std::shared_ptr<const renf_class> k);
     // An integer in the field k
-    renf_elem_class(std::shared_ptr<const renf_class> k, const mpz_class &) noexcept;
+    renf_elem_class(std::shared_ptr<const renf_class> k, const mpz_class &);
     // A rational in the field k
-    renf_elem_class(std::shared_ptr<const renf_class> k, const mpq_class &) noexcept;
+    renf_elem_class(std::shared_ptr<const renf_class> k, const mpq_class &);
     // A rational in the field k
-    renf_elem_class(std::shared_ptr<const renf_class> k, const fmpq_t) noexcept;
+    renf_elem_class(std::shared_ptr<const renf_class> k, const fmpq_t);
     // An integer in the field k
-    renf_elem_class(std::shared_ptr<const renf_class> k, const int) noexcept;
-    renf_elem_class(std::shared_ptr<const renf_class> k, const unsigned int) noexcept;
-    renf_elem_class(std::shared_ptr<const renf_class> k, const long) noexcept;
-    renf_elem_class(std::shared_ptr<const renf_class> k, const unsigned long) noexcept;
-    renf_elem_class(std::shared_ptr<const renf_class> k, const long long) noexcept;
-    renf_elem_class(std::shared_ptr<const renf_class> k, const unsigned long long) noexcept;
+    renf_elem_class(std::shared_ptr<const renf_class> k, const int);
+    renf_elem_class(std::shared_ptr<const renf_class> k, const unsigned int);
+    renf_elem_class(std::shared_ptr<const renf_class> k, const long);
+    renf_elem_class(std::shared_ptr<const renf_class> k, const unsigned long);
+    renf_elem_class(std::shared_ptr<const renf_class> k, const long long);
+    renf_elem_class(std::shared_ptr<const renf_class> k, const unsigned long long);
     // Coerce number field element to the field k. Only implemented in trivial cases.
     renf_elem_class(std::shared_ptr<const renf_class> k, const renf_elem_class&);
     // Parse the string into an element in the field k
     renf_elem_class(std::shared_ptr<const renf_class> k, const std::string &);
     // The element Σc_i·α^i where α is the generator of the field k; the number
     // of coefficients must not exceed the degree of the field.
-    template <typename C> renf_elem_class(std::shared_ptr<const renf_class> k, const std::vector<C> &) noexcept;
+    template <typename C> renf_elem_class(std::shared_ptr<const renf_class> k, const std::vector<C> &);
 
     ~renf_elem_class() noexcept;
 
     // Note that we do not implement any operator= for other types explicitly
     // but funnel everything through the implicit constructors above and the
     // move assignment here.
-    renf_elem_class & operator=(const renf_elem_class &) noexcept;
+    renf_elem_class & operator=(const renf_elem_class &);
     renf_elem_class & operator=(renf_elem_class &&) noexcept;
 
     // containing number field
-    const renf_class& parent() const noexcept { return *nf; }
+    const renf_class& parent() const { return *nf; }
 
     // testing
-    bool is_zero() const noexcept;
-    bool is_one() const noexcept;
-    bool is_integer() const noexcept;
-    bool is_rational() const noexcept;
+    bool is_zero() const;
+    bool is_one() const;
+    bool is_integer() const;
+    bool is_rational() const;
 
     // We do not return a const renf_elem_t. Parts of the C API might need a
     // non-const one to refine the underlying representation even though they
     // are morally treating this as a const.
-    ::renf_elem_t & renf_elem_t() const noexcept;
+    ::renf_elem_t & renf_elem_t() const;
 
     // data conversion
-    mpz_class num() const noexcept;
-    mpz_class den() const noexcept;
-    explicit operator mpq_class() const noexcept;
-    std::vector<mpz_class> num_vector() const noexcept;
-    explicit operator std::string() const noexcept;
-    std::string to_string(int flags = EANTIC_STR_ALG | EANTIC_STR_D) const noexcept;
+    mpz_class num() const;
+    mpz_class den() const;
+    explicit operator mpq_class() const;
+    std::vector<mpz_class> num_vector() const;
+    explicit operator std::string() const;
+    std::string to_string(int flags = EANTIC_STR_ALG | EANTIC_STR_D) const;
 
     // gcd of numerator
-    mpz_class num_content() const noexcept;
+    mpz_class num_content() const;
 
     // floor, ceil, round, approximation
-    mpz_class floor() const noexcept;
-    mpz_class ceil() const noexcept;
-    int sgn() const noexcept;
-    explicit operator double() const noexcept;
+    mpz_class floor() const;
+    mpz_class ceil() const;
+    int sgn() const;
+    explicit operator double() const;
 
     // unary operations
-    renf_elem_class operator-() const noexcept;
-    renf_elem_class operator+() const noexcept;
-    explicit operator bool() const noexcept;
+    renf_elem_class operator-() const;
+    renf_elem_class operator+() const;
+    explicit operator bool() const;
 
     // binary operations between elements in the same number field
-    renf_elem_class & operator+=(const renf_elem_class &) noexcept;
-    renf_elem_class & operator-=(const renf_elem_class &) noexcept;
-    renf_elem_class & operator*=(const renf_elem_class &) noexcept;
+    renf_elem_class & operator+=(const renf_elem_class &);
+    renf_elem_class & operator-=(const renf_elem_class &);
+    renf_elem_class & operator*=(const renf_elem_class &);
     renf_elem_class & operator/=(const renf_elem_class &);
-    bool operator==(const renf_elem_class &) const noexcept;
-    bool operator<(const renf_elem_class &) const noexcept;
+    bool operator==(const renf_elem_class &) const;
+    bool operator<(const renf_elem_class &) const;
 
     // powering
-    renf_elem_class pow(int) const noexcept;
+    renf_elem_class pow(int) const;
 
     // binary operations with primitive integer types
-    renf_elem_class & operator+=(int) noexcept;
-    renf_elem_class & operator-=(int) noexcept;
-    renf_elem_class & operator*=(int) noexcept;
+    renf_elem_class & operator+=(int);
+    renf_elem_class & operator-=(int);
+    renf_elem_class & operator*=(int);
     renf_elem_class & operator/=(int);
-    bool operator==(int) const noexcept;
-    bool operator<(int) const noexcept;
-    bool operator>(int) const noexcept;
+    bool operator==(int) const;
+    bool operator<(int) const;
+    bool operator>(int) const;
 
-    renf_elem_class & operator+=(unsigned int) noexcept;
-    renf_elem_class & operator-=(unsigned int) noexcept;
-    renf_elem_class & operator*=(unsigned int) noexcept;
+    renf_elem_class & operator+=(unsigned int);
+    renf_elem_class & operator-=(unsigned int);
+    renf_elem_class & operator*=(unsigned int);
     renf_elem_class & operator/=(unsigned int);
-    bool operator==(unsigned int) const noexcept;
-    bool operator<(unsigned int) const noexcept;
-    bool operator>(unsigned int) const noexcept;
+    bool operator==(unsigned int) const;
+    bool operator<(unsigned int) const;
+    bool operator>(unsigned int) const;
 
-    renf_elem_class & operator+=(long) noexcept;
-    renf_elem_class & operator-=(long) noexcept;
-    renf_elem_class & operator*=(long) noexcept;
+    renf_elem_class & operator+=(long);
+    renf_elem_class & operator-=(long);
+    renf_elem_class & operator*=(long);
     renf_elem_class & operator/=(long);
-    bool operator==(long) const noexcept;
-    bool operator<(long) const noexcept;
-    bool operator>(long) const noexcept;
+    bool operator==(long) const;
+    bool operator<(long) const;
+    bool operator>(long) const;
 
-    renf_elem_class & operator+=(unsigned long) noexcept;
-    renf_elem_class & operator-=(unsigned long) noexcept;
-    renf_elem_class & operator*=(unsigned long) noexcept;
+    renf_elem_class & operator+=(unsigned long);
+    renf_elem_class & operator-=(unsigned long);
+    renf_elem_class & operator*=(unsigned long);
     renf_elem_class & operator/=(unsigned long);
-    bool operator==(unsigned long) const noexcept;
-    bool operator<(unsigned long) const noexcept;
-    bool operator>(unsigned long) const noexcept;
+    bool operator==(unsigned long) const;
+    bool operator<(unsigned long) const;
+    bool operator>(unsigned long) const;
 
-    renf_elem_class & operator+=(long long) noexcept;
-    renf_elem_class & operator-=(long long) noexcept;
-    renf_elem_class & operator*=(long long) noexcept;
+    renf_elem_class & operator+=(long long);
+    renf_elem_class & operator-=(long long);
+    renf_elem_class & operator*=(long long);
     renf_elem_class & operator/=(long long);
-    bool operator==(long long) const noexcept;
-    bool operator<(long long) const noexcept;
-    bool operator>(long long) const noexcept;
+    bool operator==(long long) const;
+    bool operator<(long long) const;
+    bool operator>(long long) const;
 
-    renf_elem_class & operator+=(unsigned long long) noexcept;
-    renf_elem_class & operator-=(unsigned long long) noexcept;
-    renf_elem_class & operator*=(unsigned long long) noexcept;
+    renf_elem_class & operator+=(unsigned long long);
+    renf_elem_class & operator-=(unsigned long long);
+    renf_elem_class & operator*=(unsigned long long);
     renf_elem_class & operator/=(unsigned long long);
-    bool operator==(unsigned long long) const noexcept;
-    bool operator<(unsigned long long) const noexcept;
-    bool operator>(unsigned long long) const noexcept;
+    bool operator==(unsigned long long) const;
+    bool operator<(unsigned long long) const;
+    bool operator>(unsigned long long) const;
 
     // binary operations with GMP integers
-    renf_elem_class& operator+=(const mpz_class&) noexcept;
-    renf_elem_class& operator-=(const mpz_class&) noexcept;
-    renf_elem_class& operator*=(const mpz_class&) noexcept;
+    renf_elem_class& operator+=(const mpz_class&);
+    renf_elem_class& operator-=(const mpz_class&);
+    renf_elem_class& operator*=(const mpz_class&);
     renf_elem_class& operator/=(const mpz_class&);
-    bool operator==(const mpz_class&) const noexcept;
-    bool operator<(const mpz_class&) const noexcept;
-    bool operator>(const mpz_class&) const noexcept;
+    bool operator==(const mpz_class&) const;
+    bool operator<(const mpz_class&) const;
+    bool operator>(const mpz_class&) const;
 
     // binary operations with rational numbers
-    renf_elem_class& operator+=(const mpq_class&) noexcept;
-    renf_elem_class& operator-=(const mpq_class&) noexcept;
-    renf_elem_class& operator*=(const mpq_class&) noexcept;
+    renf_elem_class& operator+=(const mpq_class&);
+    renf_elem_class& operator-=(const mpq_class&);
+    renf_elem_class& operator*=(const mpq_class&);
     renf_elem_class& operator/=(const mpq_class&);
-    bool operator==(const mpq_class&) const noexcept;
-    bool operator<(const mpq_class&) const noexcept;
-    bool operator>(const mpq_class&) const noexcept;
+    bool operator==(const mpq_class&) const;
+    bool operator<(const mpq_class&) const;
+    bool operator>(const mpq_class&) const;
 
     // deprecated pre-1.0 methods
-    [[deprecated("use to_string() instead")]] std::string get_str(int flag = EANTIC_STR_ALG | EANTIC_STR_D) const noexcept;
+    [[deprecated("use to_string() instead")]] std::string get_str(int flag = EANTIC_STR_ALG | EANTIC_STR_D) const;
     [[deprecated("use renf_elem_t() instead")]] renf_elem_srcptr get_renf_elem() const;
     [[deprecated("use den() instead")]] mpz_class get_den() const;
     [[deprecated("use num() instead")]] mpz_class get_num() const;
     [[deprecated("use static_cast<mpq_class>() instead")]] mpq_class get_rational() const;
-    [[deprecated("use num_vector() instead")]] std::vector<mpz_class> get_num_vector() const noexcept;
-    [[deprecated("use static_cast<double>() instead")]] double get_d() const noexcept;
+    [[deprecated("use num_vector() instead")]] std::vector<mpz_class> get_num_vector() const;
+    [[deprecated("use static_cast<double>() instead")]] double get_d() const;
 
     // I/O
     friend std::ostream & operator<<(std::ostream &, const renf_elem_class &);
     friend std::istream & operator>>(std::istream &, renf_elem_class &);
 
 private:
-    // The parent number field
+    // The parent number field.
     std::shared_ptr<const renf_class> nf;
     // The underlying element.
     // We need mutability as calls might need to refine the precision of
@@ -294,12 +294,12 @@ renf_elem_class pow(renf_elem_class x, int exp);
 namespace std {
 template <>
 struct hash<eantic::renf_class> {
-  size_t operator()(const eantic::renf_class&) const noexcept;
+  size_t operator()(const eantic::renf_class&) const;
 };
 
 template <>
 struct hash<eantic::renf_elem_class> {
-  size_t operator()(const eantic::renf_elem_class&) const noexcept;
+  size_t operator()(const eantic::renf_elem_class&) const;
 };
 }  // namespace std
 

--- a/news/100.rst
+++ b/news/100.rst
@@ -60,8 +60,8 @@
   ```
 * `string renf_class::gen_name` is now a method so it needs to be called.
 * Many operations that threw an exception before when domains were mixed, now
-  abort program execution (typically through a call to `assert()`.) You can
-  identify these operations by their `noexcept` modifier.
+  abort program execution (typically through a call to `assert()`.) You are not
+  supposed to mix domains unless explicitly stated otherwise.
 * `renf_class.operator==` now also checks that the generator name is the same.
   Similarly, `renf_class.operator=` now also resets the generator name.
 

--- a/news/100.rst
+++ b/news/100.rst
@@ -1,0 +1,88 @@
+**Added:**
+
+* ` renf_elem_swap(renf_elem_t, renf_elem_t)`
+* There is now `e-antic/renfxx_fwd.h` if you only need forward declarations of
+  `renf_class` and `renf_elem_class`.
+* `renf_elem_class` can now be created from signed and unsigned long long.
+* `renf_elem_class` can now be created from vectors of primitive integers, e.g.,
+  ```
+  renf_elem_class x(K, {1, 2, 3}); // = 3*x^2 + 2*x + 1
+  ```
+  where before the entries of the vector had to be `mpz_class`.
+* Move semantics `&&` have been added to `renf_elem_class`.
+* There is now support for serialization with cereal. See t-cereal.cpp for
+  examples on how to use it.
+
+**Fixed:**
+
+* e-antic had claimed to be thread safe via an open MP pragma (in the number
+  field refinement). In some cases, there was a problem with thread-safety. We
+  now require users to explicitly mark multithreaded sections by forbidding
+  mutations to a renf, see `renf_set_immutable`. As a result, there are some
+  operations that cannot be done anymore in a multi-threaded environment but
+  they now fail properly (instead of leading to random crashes.)
+
+**Changed:**
+
+* `e-antic/renfxx.h` now requires C++17.
+* All classes are now declared in the namespace `eantic`.
+* The semantics of `operator =` have changed. In e-antic 0.1 the following
+  would create the unit in the field K.
+  ```
+  renf_elem_class x(K);
+  x = 1;
+  ```
+  Now the above statement makes x a rational number. More generally, an
+  assignment resets the number field so that after `x = y` the condition
+  `x.nf == renf_elem_class(y).nf` holds. To mimic the old behavior you need
+  to rewrite the above as
+  ```
+  renf_elem_class x(K);
+  x = renf_elem_class(K, 1);
+  ```
+* `renf_class` is now hidden behind a factory to get shared_ptr semantics
+  everywhere. Create a `renf_class` by calling `renf_class::make(…)`. This
+	returns a smart pointer, so you might have to replace some `.` with `->`.
+* The change of semantics in assignment also affects reading from streams (in
+  order to create `renf_elem_class`). Before the following would parse an element
+  into a number field:
+  ```
+  renf_elem_class x(K);
+  in >> x;
+  ```
+  Now this only works if the stream contains a rational number. (Otherwise an
+  exception is raised.) As `in >> x` also resets `x.nf`. The above code should
+  be replaced with:
+  ```
+  renf_elem_class x;
+  K.set_pword(in);
+  in >> x;
+  ```
+* `string renf_class::gen_name` is now a method so it needs to be called.
+* Many operations that threw an exception before when domains were mixed, now
+  abort program execution (typically through a call to `assert()`.) You can
+  identify these operations by their `noexcept` modifier.
+* `renf_class.operator==` now also checks that the generator name is the same.
+  Similarly, `renf_class.operator=` now also resets the generator name.
+
+**Deprecated:**
+
+* Some methods have been deprecated and might be removed in a future release,
+  mostly to make the interface more consistent. The deprecation warnings give
+  hints which methods to use instead.
+
+**Removed:**
+
+* `renf_elem_class(string&)` has been removed. If you want to parse a rational
+  number, use `renf_elem_class(mpq_class(string))`. If you want to parse into a
+  number field, use `renf_elem_class(renf_class&, string&)`.
+* `renf_elem_class::operator=(string&)` has been removed. If you want to parse
+  a rational into an element, use `x = mpq_class(string)`. If you want to parse
+  into a number field, use `x = renf_elem_class(x.parent(), string)`.
+* `renf_elem_class(vector<...>)` have been removed as it would have thrown an
+  exception always anyway.
+* `renf_elem_class::operator=(vector<...>)` have been removed due to the change
+  of semantics of `=`. If `x` is not a rational you get the same behaviour as
+  before with `x = renf_elem_class(x.parent(), {1, 2, 3})`.
+* `renf_class::xalloc()` has been removed and replaced by an implementation
+  detail.

--- a/news/TEMPLATE.rst
+++ b/news/TEMPLATE.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/rever.rst
+++ b/news/rever.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* the release process has been automated with [rever](https://regro.github.io/rever-docs/)

--- a/renfxx/renf_class.cpp
+++ b/renfxx/renf_class.cpp
@@ -12,7 +12,7 @@
 
 #include <iostream>
 
-#include <e-antic/renfxx.h>
+#include "../e-antic/renfxx.h"
 #include "external/unique-factory/unique_factory.hpp"
 
 namespace {
@@ -34,7 +34,7 @@ static unique_factory::UniqueFactory<std::weak_ptr<eantic::renf_class>, Key> fac
 
 namespace eantic {
 
-renf_class::renf_class() noexcept
+renf_class::renf_class()
 {
     fmpq_poly_t minpoly;
     arb_t emb;
@@ -54,7 +54,7 @@ renf_class::renf_class() noexcept
     name = "a";
 }
 
-renf_class::renf_class(const ::renf_t k, const std::string & gen_name) noexcept
+renf_class::renf_class(const ::renf_t k, const std::string & gen_name)
 {
     renf_init_set(nf, k);
     this->name = gen_name;
@@ -86,13 +86,13 @@ renf_class::renf_class(const std::string & minpoly, const std::string & gen, con
     arb_clear(e);
 }
 
-std::shared_ptr<const renf_class> renf_class::make() noexcept
+std::shared_ptr<const renf_class> renf_class::make()
 {
     static auto trivial = factory.get(Key(new renf_class()), [&]() { return new renf_class; });
     return trivial;
 }
 
-std::shared_ptr<const renf_class> renf_class::make(const ::renf_t k, const std::string & gen_name) noexcept
+std::shared_ptr<const renf_class> renf_class::make(const ::renf_t k, const std::string & gen_name)
 {
     return factory.get(Key(new renf_class(k, gen_name)), [&]() { return new renf_class(k, gen_name); });
 }
@@ -104,42 +104,42 @@ std::shared_ptr<const renf_class> renf_class::make(const std::string & minpoly, 
 
 renf_class::~renf_class() noexcept { renf_clear(nf); }
 
-slong renf_class::degree() const noexcept { return fmpq_poly_degree(nf->nf->pol); }
+slong renf_class::degree() const { return fmpq_poly_degree(nf->nf->pol); }
 
-renf_elem_class renf_class::zero() const noexcept
+renf_elem_class renf_class::zero() const
 {
     renf_elem_class a(this->shared_from_this(), 0);
     return a;
 }
 
-renf_elem_class renf_class::one() const noexcept
+renf_elem_class renf_class::one() const
 {
     renf_elem_class a(this->shared_from_this(), 1);
     return a;
 }
 
-renf_elem_class renf_class::gen() const noexcept
+renf_elem_class renf_class::gen() const
 {
     renf_elem_class a(this->shared_from_this());
     renf_elem_gen(a.renf_elem_t(), this->renf_t());
     return a;
 }
 
-bool renf_class::operator==(const renf_class & other) const noexcept
+bool renf_class::operator==(const renf_class & other) const
 {
     return (this->nf == other.nf || renf_equal(this->nf, other.nf))
       && this->name == other.name;
 }
 
-std::istream & renf_class::set_pword(std::istream & is) const noexcept
+std::istream & renf_class::set_pword(std::istream & is) const
 {
     is.pword(xalloc) = const_cast<void*>(reinterpret_cast<const void*>(this));
     return is;
 }
 
-std::istream & renf_class::set_istream(std::istream & is) const noexcept { return set_pword(is); }
+std::istream & renf_class::set_istream(std::istream & is) const { return set_pword(is); }
 
-std::string renf_class::to_string() const noexcept
+std::string renf_class::to_string() const
 {
     char * u = renf_get_str(renf_t(), gen_name().c_str(), 64);
     std::string s = u;
@@ -202,7 +202,7 @@ std::istream & operator>>(std::istream & is, renf_elem_class & a)
 } // end of namespace eantic
 
 namespace std {
-size_t hash<eantic::renf_class>::operator()(const eantic::renf_class& nf) const noexcept
+size_t hash<eantic::renf_class>::operator()(const eantic::renf_class& nf) const
 {
     return hash<eantic::renf_elem_class>()(nf.gen());
 }

--- a/renfxx/renf_elem_class.cpp
+++ b/renfxx/renf_elem_class.cpp
@@ -15,7 +15,8 @@
 #include <iostream>
 #include <cstdlib>
 #include <functional>
-#include <e-antic/renfxx.h>
+
+#include "../e-antic/renfxx.h"
 
 namespace eantic {
 
@@ -97,7 +98,7 @@ template <typename Integer>
 using Supported = std::conditional_t<std::is_signed<Integer>::value, slong, ulong>;
 
 template <typename Integer>
-void maybe_fmpz(Integer value, const std::function<void(Supported<Integer>)>& op, const std::function<void(const fmpz_t)>& fmpz_op) noexcept
+void maybe_fmpz(Integer value, const std::function<void(Supported<Integer>)>& op, const std::function<void(const fmpz_t)>& fmpz_op)
 {
      try
      {
@@ -114,7 +115,7 @@ void maybe_fmpz(Integer value, const std::function<void(Supported<Integer>)>& op
 }
 
 template <typename Integer>
-void assign_maybe_fmpz(renf_elem_class& lhs, Integer value, const std::function<void(renf_elem_t, Supported<Integer>, const renf_t)>& op) noexcept
+void assign_maybe_fmpz(renf_elem_class& lhs, Integer value, const std::function<void(renf_elem_t, Supported<Integer>, const renf_t)>& op)
 {
     maybe_fmpz(value,
         [&](auto v) { op(lhs.renf_elem_t(), v, lhs.parent().renf_t()); },
@@ -122,7 +123,7 @@ void assign_maybe_fmpz(renf_elem_class& lhs, Integer value, const std::function<
 }
 
 template <typename Integer>
-renf_elem_class & binop_maybe_fmpz(renf_elem_class& lhs, Integer rhs, const std::function<void(renf_elem_t, const renf_elem_t, Supported<Integer>, const renf_t)>& op, const std::function<void(renf_elem_t, const renf_elem_t, const fmpz_t, const renf_t)>& fmpz_op) noexcept
+renf_elem_class & binop_maybe_fmpz(renf_elem_class& lhs, Integer rhs, const std::function<void(renf_elem_t, const renf_elem_t, Supported<Integer>, const renf_t)>& op, const std::function<void(renf_elem_t, const renf_elem_t, const fmpz_t, const renf_t)>& fmpz_op)
 {
     maybe_fmpz(rhs,
         [&](auto v) { op(lhs.renf_elem_t(), lhs.renf_elem_t(), v, lhs.parent().renf_t()); },
@@ -131,7 +132,7 @@ renf_elem_class & binop_maybe_fmpz(renf_elem_class& lhs, Integer rhs, const std:
 }
 
 template <typename Integer>
-bool relop_maybe_fmpz(const renf_elem_class& lhs, Integer rhs, const std::function<int(renf_elem_t, Supported<Integer>, renf_t)>& op) noexcept
+bool relop_maybe_fmpz(const renf_elem_class& lhs, Integer rhs, const std::function<int(renf_elem_t, Supported<Integer>, renf_t)>& op)
 {
     if (!lhs.is_integer())
         return false;
@@ -146,7 +147,7 @@ bool relop_maybe_fmpz(const renf_elem_class& lhs, Integer rhs, const std::functi
 }
 
 template <typename Integer>
-bool relop_maybe_fmpz(const renf_elem_class& lhs, Integer rhs, const std::function<int(renf_elem_t, Supported<Integer>, renf_t)>& op, int cmp) noexcept
+bool relop_maybe_fmpz(const renf_elem_class& lhs, Integer rhs, const std::function<int(renf_elem_t, Supported<Integer>, renf_t)>& op, int cmp)
 {
     bool ret;
 
@@ -164,101 +165,101 @@ renf_elem_class::renf_elem_class() noexcept
 {
 }
 
-renf_elem_class::renf_elem_class(const renf_elem_class & value) noexcept
+renf_elem_class::renf_elem_class(const renf_elem_class & value)
     : renf_elem_class(value.nf)
 {
     *this = value;
 }
 
 renf_elem_class::renf_elem_class(renf_elem_class && value) noexcept
-    : renf_elem_class(value.nf)
+    : nf(std::move(value.nf))
 {
-    *this = std::move(value);
+    *a = *value.a;
 }
 
-renf_elem_class::renf_elem_class(int value) noexcept
+renf_elem_class::renf_elem_class(int value)
     : renf_elem_class(renf_class::make(), value) {}
 
-renf_elem_class::renf_elem_class(unsigned int value) noexcept
+renf_elem_class::renf_elem_class(unsigned int value)
     : renf_elem_class(renf_class::make(), value) {}
 
-renf_elem_class::renf_elem_class(long value) noexcept
+renf_elem_class::renf_elem_class(long value)
     : renf_elem_class(renf_class::make(), value) {}
 
-renf_elem_class::renf_elem_class(unsigned long value) noexcept
+renf_elem_class::renf_elem_class(unsigned long value)
     : renf_elem_class(renf_class::make(), value) {}
 
-renf_elem_class::renf_elem_class(long long value) noexcept
+renf_elem_class::renf_elem_class(long long value)
     : renf_elem_class(renf_class::make(), value) {}
 
-renf_elem_class::renf_elem_class(unsigned long long value) noexcept
+renf_elem_class::renf_elem_class(unsigned long long value)
     : renf_elem_class(renf_class::make(), value) {}
 
-renf_elem_class::renf_elem_class(const mpz_class & value) noexcept
+renf_elem_class::renf_elem_class(const mpz_class & value)
     : renf_elem_class(renf_class::make(), value) {}
 
-renf_elem_class::renf_elem_class(const mpq_class & value) noexcept
+renf_elem_class::renf_elem_class(const mpq_class & value)
     : renf_elem_class(renf_class::make(), value) {}
 
-renf_elem_class::renf_elem_class(const ::fmpq_t value) noexcept
+renf_elem_class::renf_elem_class(const ::fmpq_t value)
     : renf_elem_class(renf_class::make(), value) {}
 
-renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k) noexcept
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k)
     : nf(std::move(k))
 {
     renf_elem_init(a, nf->renf_t());
     renf_elem_zero(a, nf->renf_t());
 }
 
-renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, int value) noexcept
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, int value)
     : renf_elem_class(std::move(k), static_cast<long>(value)) {}
 
-renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, unsigned int value) noexcept
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, unsigned int value)
     : renf_elem_class(std::move(k), static_cast<unsigned long>(value)) {}
 
-renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, long value) noexcept
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, long value)
     : nf(std::move(k))
 {
     renf_elem_init(a, nf->renf_t());
     renf_elem_set_si(a, value, nf->renf_t());
 }
 
-renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, unsigned long value) noexcept
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, unsigned long value)
     : nf(std::move(k))
 {
     renf_elem_init(a, nf->renf_t());
     renf_elem_set_ui(a, value, nf->renf_t());
 }
 
-renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, long long value) noexcept
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, long long value)
     : nf(std::move(k))
 {
     renf_elem_init(a, nf->renf_t());
     assign_maybe_fmpz(*this, value, renf_elem_set_si);
 }
 
-renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, unsigned long long value) noexcept
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, unsigned long long value)
     : nf(std::move(k))
 {
     renf_elem_init(a, nf->renf_t());
     assign_maybe_fmpz(*this, value, renf_elem_set_ui);
 }
 
-renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, const mpz_class & value) noexcept
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, const mpz_class & value)
     : nf(std::move(k))
 {
     renf_elem_init(a, nf->renf_t());
     renf_elem_set_mpz(a, value.get_mpz_t(), nf->renf_t());
 }
 
-renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, const mpq_class & value) noexcept
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, const mpq_class & value)
     : nf(std::move(k))
 {
     renf_elem_init(a, nf->renf_t());
     renf_elem_set_mpq(a, value.get_mpq_t(), nf->renf_t());
 }
 
-renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, const ::fmpq_t value) noexcept
+renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, const ::fmpq_t value)
     : nf(std::move(k))
 {
     renf_elem_init(a, nf->renf_t());
@@ -317,10 +318,12 @@ renf_elem_class::renf_elem_class(std::shared_ptr<const renf_class> k, const renf
 
 renf_elem_class::~renf_elem_class() noexcept
 {
-    renf_elem_clear(a, nf->renf_t());
+    // When this element has been moved out by the move-constructor, then nf is
+    // null and a points to another element's storage.
+    if (nf) renf_elem_clear(a, nf->renf_t());
 }
 
-renf_elem_class & renf_elem_class::operator=(const renf_elem_class & value) noexcept
+renf_elem_class & renf_elem_class::operator=(const renf_elem_class & value)
 {
     if (value.nf != nf)
     {
@@ -342,32 +345,32 @@ renf_elem_class & renf_elem_class::operator=(renf_elem_class && value) noexcept
     return *this;
 }
 
-bool renf_elem_class::is_zero() const noexcept
+bool renf_elem_class::is_zero() const
 {
     return renf_elem_is_zero(a, nf->renf_t());
 }
 
-bool renf_elem_class::is_one() const noexcept
+bool renf_elem_class::is_one() const
 {
     return renf_elem_is_one(a, nf->renf_t());
 }
 
-bool renf_elem_class::is_integer() const noexcept
+bool renf_elem_class::is_integer() const
 {
     return renf_elem_is_integer(a, nf->renf_t());
 }
 
-bool renf_elem_class::is_rational() const noexcept
+bool renf_elem_class::is_rational() const
 {
     return renf_elem_is_rational(a, nf->renf_t());
 }
 
-::renf_elem_t & renf_elem_class::renf_elem_t() const noexcept
+::renf_elem_t & renf_elem_class::renf_elem_t() const
 {
     return a;
 }
 
-mpz_class renf_elem_class::num() const noexcept {
+mpz_class renf_elem_class::num() const {
     mpz_class x;
 
     if (nf->renf_t()->nf->flag & NF_LINEAR)
@@ -391,7 +394,7 @@ mpz_class renf_elem_class::num() const noexcept {
     return x;
 }
 
-mpz_class renf_elem_class::num_content() const noexcept {
+mpz_class renf_elem_class::num_content() const {
     mpz_class x;
 
     if (nf->renf_t()->nf->flag & NF_LINEAR)
@@ -420,7 +423,7 @@ mpz_class renf_elem_class::num_content() const noexcept {
     return x;
 }
 
-mpz_class renf_elem_class::den() const noexcept {
+mpz_class renf_elem_class::den() const {
     mpz_class res;
 
     fmpz_t z;
@@ -432,7 +435,7 @@ mpz_class renf_elem_class::den() const noexcept {
     return res;
 }
 
-renf_elem_class::operator mpq_class() const noexcept
+renf_elem_class::operator mpq_class() const
 {
     mpq_class z;
 
@@ -455,7 +458,7 @@ renf_elem_class::operator mpq_class() const noexcept
     return z;
 }
 
-std::vector<mpz_class> renf_elem_class::num_vector() const noexcept
+std::vector<mpz_class> renf_elem_class::num_vector() const
 {
     mpz_class x;
     std::vector<mpz_class> res;
@@ -476,12 +479,12 @@ std::vector<mpz_class> renf_elem_class::num_vector() const noexcept
     return res;
 }
 
-renf_elem_class::operator std::string() const noexcept
+renf_elem_class::operator std::string() const
 {
     return to_string();
 }
 
-std::string renf_elem_class::to_string(int flags) const noexcept
+std::string renf_elem_class::to_string(int flags) const
 {
     std::string s;
 
@@ -497,7 +500,7 @@ std::string renf_elem_class::to_string(int flags) const noexcept
         return s;
 }
 
-mpz_class renf_elem_class::floor() const noexcept
+mpz_class renf_elem_class::floor() const
 {
     fmpz_t tmp;
     fmpz_init(tmp);
@@ -510,7 +513,7 @@ mpz_class renf_elem_class::floor() const noexcept
     return z;
 }
 
-mpz_class renf_elem_class::ceil() const noexcept
+mpz_class renf_elem_class::ceil() const
 {
     fmpz_t tmp;
     fmpz_init(tmp);
@@ -523,41 +526,41 @@ mpz_class renf_elem_class::ceil() const noexcept
     return z;
 }
 
-int renf_elem_class::sgn() const noexcept
+int renf_elem_class::sgn() const
 {
     return renf_elem_sgn(a, nf->renf_t());
 }
 
-renf_elem_class::operator double() const noexcept
+renf_elem_class::operator double() const
 {
     return renf_elem_get_d(a, nf->renf_t(), ARF_RND_NEAR);
 }
 
-renf_elem_class renf_elem_class::operator-() const noexcept
+renf_elem_class renf_elem_class::operator-() const
 {
     renf_elem_class ans(*this);
     renf_elem_neg(ans.a, ans.a, ans.nf->renf_t());
     return ans;
 }
 
-renf_elem_class renf_elem_class::operator+() const noexcept { return *this; }
+renf_elem_class renf_elem_class::operator+() const { return *this; }
 
-renf_elem_class::operator bool() const noexcept
+renf_elem_class::operator bool() const
 {
     return *this != 0;
 }
 
-renf_elem_class & renf_elem_class::operator+=(const renf_elem_class & rhs) noexcept
+renf_elem_class & renf_elem_class::operator+=(const renf_elem_class & rhs)
 {
     return binop(*this, rhs, renf_elem_add);
 }
 
-renf_elem_class & renf_elem_class::operator-=(const renf_elem_class & rhs) noexcept
+renf_elem_class & renf_elem_class::operator-=(const renf_elem_class & rhs)
 {
     return binop(*this, rhs, renf_elem_sub);
 }
 
-renf_elem_class & renf_elem_class::operator*=(const renf_elem_class & rhs) noexcept
+renf_elem_class & renf_elem_class::operator*=(const renf_elem_class & rhs)
 {
     return binop(*this, rhs, renf_elem_mul);
 }
@@ -567,7 +570,7 @@ renf_elem_class & renf_elem_class::operator/=(const renf_elem_class & rhs)
     return binop(*this, rhs, renf_elem_div);
 }
 
-renf_elem_class renf_elem_class::pow(int exp) const noexcept
+renf_elem_class renf_elem_class::pow(int exp) const
 {
     renf_elem_class res(nf);
 
@@ -584,7 +587,7 @@ renf_elem_class renf_elem_class::pow(int exp) const noexcept
     return res;
 }
 
-bool renf_elem_class::operator==(const renf_elem_class & other) const noexcept
+bool renf_elem_class::operator==(const renf_elem_class & other) const
 {
     if (*nf == *other.nf)
       return renf_elem_equal(a, other.a, nf->renf_t());
@@ -607,7 +610,7 @@ bool renf_elem_class::operator==(const renf_elem_class & other) const noexcept
     }
 }
 
-bool renf_elem_class::operator<(const renf_elem_class & other) const noexcept
+bool renf_elem_class::operator<(const renf_elem_class & other) const
 {
     if (*nf == *other.nf)
         return renf_elem_cmp(a, other.a, nf->renf_t()) < 0;
@@ -629,17 +632,17 @@ bool renf_elem_class::operator<(const renf_elem_class & other) const noexcept
     }
 }
 
-renf_elem_class& renf_elem_class::operator+=(int rhs) noexcept
+renf_elem_class& renf_elem_class::operator+=(int rhs)
 {
     return *this += static_cast<long>(rhs);
 }
 
-renf_elem_class& renf_elem_class::operator-=(int rhs) noexcept
+renf_elem_class& renf_elem_class::operator-=(int rhs)
 {
     return *this -= static_cast<long>(rhs);
 }
 
-renf_elem_class& renf_elem_class::operator*=(int rhs) noexcept
+renf_elem_class& renf_elem_class::operator*=(int rhs)
 {
     return *this *= static_cast<long>(rhs);
 }
@@ -649,29 +652,29 @@ renf_elem_class& renf_elem_class::operator/=(int rhs)
     return *this /= static_cast<long>(rhs);
 }
 
-bool renf_elem_class::operator==(int rhs) const noexcept {
+bool renf_elem_class::operator==(int rhs) const {
     return *this == static_cast<long>(rhs);
 }
 
-bool renf_elem_class::operator<(int rhs) const noexcept {
+bool renf_elem_class::operator<(int rhs) const {
     return *this < static_cast<long>(rhs);
 }
 
-bool renf_elem_class::operator>(int rhs) const noexcept {
+bool renf_elem_class::operator>(int rhs) const {
     return *this > static_cast<long>(rhs);
 }
 
-renf_elem_class& renf_elem_class::operator+=(unsigned int rhs) noexcept
+renf_elem_class& renf_elem_class::operator+=(unsigned int rhs)
 {
     return *this += static_cast<unsigned long>(rhs);
 }
 
-renf_elem_class& renf_elem_class::operator-=(unsigned int rhs) noexcept
+renf_elem_class& renf_elem_class::operator-=(unsigned int rhs)
 {
     return *this -= static_cast<unsigned long>(rhs);
 }
 
-renf_elem_class& renf_elem_class::operator*=(unsigned int rhs) noexcept
+renf_elem_class& renf_elem_class::operator*=(unsigned int rhs)
 {
     return *this *= static_cast<unsigned long>(rhs);
 }
@@ -681,31 +684,31 @@ renf_elem_class& renf_elem_class::operator/=(unsigned int rhs)
     return *this /= static_cast<unsigned long>(rhs);
 }
 
-bool renf_elem_class::operator==(unsigned int rhs) const noexcept {
+bool renf_elem_class::operator==(unsigned int rhs) const {
     return *this == static_cast<unsigned long>(rhs);
 }
 
-bool renf_elem_class::operator<(unsigned int rhs) const noexcept {
+bool renf_elem_class::operator<(unsigned int rhs) const {
     return *this < static_cast<unsigned long>(rhs);
 }
 
-bool renf_elem_class::operator>(unsigned int rhs) const noexcept {
+bool renf_elem_class::operator>(unsigned int rhs) const {
     return *this > static_cast<unsigned long>(rhs);
 }
 
-renf_elem_class& renf_elem_class::operator+=(long rhs) noexcept
+renf_elem_class& renf_elem_class::operator+=(long rhs)
 {
     renf_elem_add_si(renf_elem_t(), renf_elem_t(), rhs, nf->renf_t());
     return *this;
 }
 
-renf_elem_class& renf_elem_class::operator-=(long rhs) noexcept
+renf_elem_class& renf_elem_class::operator-=(long rhs)
 {
     renf_elem_sub_si(renf_elem_t(), renf_elem_t(), rhs, nf->renf_t());
     return *this;
 }
 
-renf_elem_class& renf_elem_class::operator*=(long rhs) noexcept
+renf_elem_class& renf_elem_class::operator*=(long rhs)
 {
     renf_elem_mul_si(renf_elem_t(), renf_elem_t(), rhs, nf->renf_t());
     return *this;
@@ -717,31 +720,31 @@ renf_elem_class& renf_elem_class::operator/=(long rhs)
     return *this;
 }
 
-bool renf_elem_class::operator==(long rhs) const noexcept {
+bool renf_elem_class::operator==(long rhs) const {
     return renf_elem_equal_si(renf_elem_t(), rhs, nf->renf_t());
 }
 
-bool renf_elem_class::operator<(long rhs) const noexcept {
+bool renf_elem_class::operator<(long rhs) const {
     return renf_elem_cmp_si(renf_elem_t(), rhs, nf->renf_t()) == -1;
 }
 
-bool renf_elem_class::operator>(long rhs) const noexcept {
+bool renf_elem_class::operator>(long rhs) const {
     return renf_elem_cmp_si(renf_elem_t(), rhs, nf->renf_t()) == 1;
 }
 
-renf_elem_class& renf_elem_class::operator+=(unsigned long rhs) noexcept
+renf_elem_class& renf_elem_class::operator+=(unsigned long rhs)
 {
     renf_elem_add_ui(renf_elem_t(), renf_elem_t(), rhs, nf->renf_t());
     return *this;
 }
 
-renf_elem_class& renf_elem_class::operator-=(unsigned long rhs) noexcept
+renf_elem_class& renf_elem_class::operator-=(unsigned long rhs)
 {
     renf_elem_sub_ui(renf_elem_t(), renf_elem_t(), rhs, nf->renf_t());
     return *this;
 }
 
-renf_elem_class& renf_elem_class::operator*=(unsigned long rhs) noexcept
+renf_elem_class& renf_elem_class::operator*=(unsigned long rhs)
 {
     renf_elem_mul_ui(renf_elem_t(), renf_elem_t(), rhs, nf->renf_t());
     return *this;
@@ -753,31 +756,31 @@ renf_elem_class& renf_elem_class::operator/=(unsigned long rhs)
     return *this;
 }
 
-bool renf_elem_class::operator==(unsigned long rhs) const noexcept {
+bool renf_elem_class::operator==(unsigned long rhs) const {
     return renf_elem_equal_ui(renf_elem_t(), rhs, nf->renf_t());
 }
 
-bool renf_elem_class::operator<(unsigned long rhs) const noexcept {
+bool renf_elem_class::operator<(unsigned long rhs) const {
     return renf_elem_cmp_ui(renf_elem_t(), rhs, nf->renf_t()) == -1;
 }
 
-bool renf_elem_class::operator>(unsigned long rhs) const noexcept {
+bool renf_elem_class::operator>(unsigned long rhs) const {
     return renf_elem_cmp_ui(renf_elem_t(), rhs, nf->renf_t()) == 1;
 }
 
-renf_elem_class& renf_elem_class::operator+=(long long rhs) noexcept
+renf_elem_class& renf_elem_class::operator+=(long long rhs)
 {
     binop_maybe_fmpz(*this, rhs, renf_elem_add_si, renf_elem_add_fmpz);
     return *this;
 }
 
-renf_elem_class& renf_elem_class::operator-=(long long rhs) noexcept
+renf_elem_class& renf_elem_class::operator-=(long long rhs)
 {
     binop_maybe_fmpz(*this, rhs, renf_elem_sub_si, renf_elem_sub_fmpz);
     return *this;
 }
 
-renf_elem_class& renf_elem_class::operator*=(long long rhs) noexcept
+renf_elem_class& renf_elem_class::operator*=(long long rhs)
 {
     binop_maybe_fmpz(*this, rhs, renf_elem_mul_si, renf_elem_mul_fmpz);
     return *this;
@@ -789,31 +792,31 @@ renf_elem_class& renf_elem_class::operator/=(long long rhs)
     return *this;
 }
 
-bool renf_elem_class::operator==(long long rhs) const noexcept {
+bool renf_elem_class::operator==(long long rhs) const {
     return relop_maybe_fmpz(*this, rhs, renf_elem_equal_si);
 }
 
-bool renf_elem_class::operator<(long long rhs) const noexcept {
+bool renf_elem_class::operator<(long long rhs) const {
     return relop_maybe_fmpz(*this, rhs, renf_elem_cmp_si, -1);
 }
 
-bool renf_elem_class::operator>(long long rhs) const noexcept {
+bool renf_elem_class::operator>(long long rhs) const {
     return relop_maybe_fmpz(*this, rhs, renf_elem_cmp_si, 1);
 }
 
-renf_elem_class& renf_elem_class::operator+=(unsigned long long rhs) noexcept
+renf_elem_class& renf_elem_class::operator+=(unsigned long long rhs)
 {
     binop_maybe_fmpz(*this, rhs, renf_elem_add_ui, renf_elem_add_fmpz);
     return *this;
 }
 
-renf_elem_class& renf_elem_class::operator-=(unsigned long long rhs) noexcept
+renf_elem_class& renf_elem_class::operator-=(unsigned long long rhs)
 {
     binop_maybe_fmpz(*this, rhs, renf_elem_sub_ui, renf_elem_sub_fmpz);
     return *this;
 }
 
-renf_elem_class& renf_elem_class::operator*=(unsigned long long rhs) noexcept
+renf_elem_class& renf_elem_class::operator*=(unsigned long long rhs)
 {
     binop_maybe_fmpz(*this, rhs, renf_elem_mul_ui, renf_elem_mul_fmpz);
     return *this;
@@ -825,29 +828,29 @@ renf_elem_class& renf_elem_class::operator/=(unsigned long long rhs)
     return *this;
 }
 
-bool renf_elem_class::operator==(unsigned long long rhs) const noexcept {
+bool renf_elem_class::operator==(unsigned long long rhs) const {
     return relop_maybe_fmpz(*this, rhs, renf_elem_equal_ui);
 }
 
-bool renf_elem_class::operator<(unsigned long long rhs) const noexcept {
+bool renf_elem_class::operator<(unsigned long long rhs) const {
     return relop_maybe_fmpz(*this, rhs, renf_elem_cmp_ui, -1);
 }
 
-bool renf_elem_class::operator>(unsigned long long rhs) const noexcept {
+bool renf_elem_class::operator>(unsigned long long rhs) const {
     return relop_maybe_fmpz(*this, rhs, renf_elem_cmp_ui, 1);
 }
 
-renf_elem_class& renf_elem_class::operator+=(const mpz_class& rhs) noexcept
+renf_elem_class& renf_elem_class::operator+=(const mpz_class& rhs)
 {
     return binop_mpz(*this, rhs, renf_elem_add_fmpz);
 }
 
-renf_elem_class& renf_elem_class::operator-=(const mpz_class& rhs) noexcept
+renf_elem_class& renf_elem_class::operator-=(const mpz_class& rhs)
 {
     return binop_mpz(*this, rhs, renf_elem_sub_fmpz);
 }
 
-renf_elem_class& renf_elem_class::operator*=(const mpz_class& rhs) noexcept
+renf_elem_class& renf_elem_class::operator*=(const mpz_class& rhs)
 {
     return binop_mpz(*this, rhs, renf_elem_mul_fmpz);
 }
@@ -857,29 +860,29 @@ renf_elem_class& renf_elem_class::operator/=(const mpz_class& rhs)
     return binop_mpz(*this, rhs, renf_elem_div_fmpz);
 }
 
-bool renf_elem_class::operator==(const mpz_class& rhs) const noexcept {
+bool renf_elem_class::operator==(const mpz_class& rhs) const {
     return relop_mpz(*this, rhs, 0);
 }
 
-bool renf_elem_class::operator<(const mpz_class& rhs) const noexcept {
+bool renf_elem_class::operator<(const mpz_class& rhs) const {
     return relop_mpz(*this, rhs, -1);
 }
 
-bool renf_elem_class::operator>(const mpz_class& rhs) const noexcept {
+bool renf_elem_class::operator>(const mpz_class& rhs) const {
     return relop_mpz(*this, rhs, 1);
 }
 
-renf_elem_class& renf_elem_class::operator+=(const mpq_class& rhs) noexcept
+renf_elem_class& renf_elem_class::operator+=(const mpq_class& rhs)
 {
     return binop_mpq(*this, rhs, renf_elem_add_fmpq);
 }
 
-renf_elem_class& renf_elem_class::operator-=(const mpq_class& rhs) noexcept
+renf_elem_class& renf_elem_class::operator-=(const mpq_class& rhs)
 {
     return binop_mpq(*this, rhs, renf_elem_sub_fmpq);
 }
 
-renf_elem_class& renf_elem_class::operator*=(const mpq_class& rhs) noexcept
+renf_elem_class& renf_elem_class::operator*=(const mpq_class& rhs)
 {
     return binop_mpq(*this, rhs, renf_elem_mul_fmpq);
 }
@@ -889,19 +892,19 @@ renf_elem_class& renf_elem_class::operator/=(const mpq_class& rhs)
     return binop_mpq(*this, rhs, renf_elem_div_fmpq);
 }
 
-bool renf_elem_class::operator==(const mpq_class& rhs) const noexcept {
+bool renf_elem_class::operator==(const mpq_class& rhs) const {
     return relop_mpq(*this, rhs, 0);
 }
 
-bool renf_elem_class::operator<(const mpq_class& rhs) const noexcept {
+bool renf_elem_class::operator<(const mpq_class& rhs) const {
     return relop_mpq(*this, rhs, -1);
 }
 
-bool renf_elem_class::operator>(const mpq_class& rhs) const noexcept {
+bool renf_elem_class::operator>(const mpq_class& rhs) const {
     return relop_mpq(*this, rhs, 1);
 }
 
-std::string renf_elem_class::get_str(int flag) const noexcept { return to_string(flag); }
+std::string renf_elem_class::get_str(int flag) const { return to_string(flag); }
 
 renf_elem_srcptr renf_elem_class::get_renf_elem(void) const
 {
@@ -914,14 +917,14 @@ mpz_class renf_elem_class::get_num(void) const { return num(); }
 
 mpq_class renf_elem_class::get_rational(void) const { return static_cast<mpq_class>(*this); }
 
-std::vector<mpz_class> renf_elem_class::get_num_vector(void) const noexcept { return num_vector(); }
+std::vector<mpz_class> renf_elem_class::get_num_vector(void) const { return num_vector(); }
 
-double renf_elem_class::get_d() const noexcept { return static_cast<double>(*this); }
+double renf_elem_class::get_d() const { return static_cast<double>(*this); }
 
 } // end of namespace eantic
 
 namespace std {
-size_t hash<eantic::renf_elem_class>::operator()(const eantic::renf_elem_class& x) const noexcept
+size_t hash<eantic::renf_elem_class>::operator()(const eantic::renf_elem_class& x) const
 {
   return hash<double>()(static_cast<double>(x));
 }

--- a/rever.xsh
+++ b/rever.xsh
@@ -1,0 +1,74 @@
+######################################################################
+#  This file is part of e-antic.
+#
+#        Copyright (C) 2020 Julian Rüth
+#
+#  e-antic is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  e-antic is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with e-antic. If not, see <https://www.gnu.org/licenses/>.
+#####################################################################
+
+import sys
+from packaging import version
+
+from rever.activity import activity
+
+try:
+  input("Are you sure you are on the master branch which is identical to origin/master and the only pending changes are a version_info bump in configure.ac? [ENTER]")
+except KeyboardInterrupt:
+  sys.exit(1)
+
+@activity
+def dist():
+    r"""
+    Run make dist and collect the resulting tarball.
+    """
+    from tempfile import TemporaryDirectory
+    from xonsh.dirstack import DIRSTACK
+    with TemporaryDirectory() as tmp:
+        ./bootstrap.sh
+        pushd @(tmp)
+        @(DIRSTACK[-1])/configure
+        make dist
+        mv *.tar.gz @(DIRSTACK[-1])
+        popd
+    return True
+
+$PROJECT = 'e-antic'
+
+$ACTIVITIES = [
+    'version_bump',
+    'changelog',
+    'dist',
+    'tag',
+    'push_tag',
+    'ghrelease',
+]
+
+MAJOR, MINOR, PATCH = version.parse($VERSION).release
+
+$VERSION_BUMP_PATTERNS = [
+    ('configure.ac', r'AC_INIT', r'AC_INIT([e-antic], [$VERSION], [vincent.delecroix@math.cnrs.fr])'),
+    ('e-antic/e-antic.h.in', r'#define E_ANTIC_VERSION ', r'#define E_ANTIC_VERSION "$VERSION"'),
+    ('e-antic/e-antic.h.in', r'#define E_ANTIC_VERSION_MAJOR', rf'#define E_ANTIC_VERSION_MAJOR {MAJOR}'),
+    ('e-antic/e-antic.h.in', r'#define E_ANTIC_VERSION_MINOR', rf'#define E_ANTIC_VERSION_MINOR {MINOR}'),
+    ('e-antic/e-antic.h.in', r'#define E_ANTIC_VERSION_PATCHLEVEL', rf'#define E_ANTIC_VERSION_PATCHLEVEL {PATCH}'),
+]
+
+$CHANGELOG_FILENAME = 'NEWS'
+$CHANGELOG_TEMPLATE = 'TEMPLATE.rst'
+$PUSH_TAG_REMOTE = 'git@github.com:videlec/e-antic.git'
+
+$GITHUB_ORG = 'videlec'
+$GITHUB_REPO = 'e-antic'
+
+$GHRELEASE_ASSETS = ['e-antic-' + $VERSION + '.tar.gz']


### PR DESCRIPTION
When I added the noexcepts I had a wrong concept on what these are good for. I am now following the advice given in https://akrzemi1.wordpress.com/2011/06/10/using-noexcept. I.e., we only use noexcept where it is actually true (most operations might end up allocating memory so they are not noexcept) and we also only put them when there is a benefit in doing so (mostly move operations so std containers use a faster code path.)

