### PR TITLE
Adapt to simplified unique-factory

### DIFF
--- a/news/TEMPLATE.rst
+++ b/news/TEMPLATE.rst
@@ -18,6 +18,6 @@
 
 * <news item>
 
-**Security:**
+**Performance:**
 
 * <news item>

--- a/news/factory.rst
+++ b/news/factory.rst
@@ -1,0 +1,7 @@
+**Fixed:**
+
+* Adapted to changes in unique-factory.
+
+**Performance:**
+
+* Speed up `renf_class::operator==`

--- a/renfxx/test/main.cpp
+++ b/renfxx/test/main.cpp
@@ -1,2 +1,12 @@
-#define CATCH_CONFIG_MAIN
+#include <flint/flint.h>
+
+#define CATCH_CONFIG_RUNNER
 #include "external/catch2/single_include/catch2/catch.hpp"
+
+int main( int argc, char* argv[] ) {
+  int result = Catch::Session().run( argc, argv );
+
+  flint_cleanup();
+
+  return result;
+}

--- a/rever.xsh
+++ b/rever.xsh
@@ -66,6 +66,7 @@ $VERSION_BUMP_PATTERNS = [
 
 $CHANGELOG_FILENAME = 'NEWS'
 $CHANGELOG_TEMPLATE = 'TEMPLATE.rst'
+$CHANGELOG_CATEGORIES = ('Added', 'Changed', 'Deprecated', 'Removed', 'Fixed', 'Performance')
 $PUSH_TAG_REMOTE = 'git@github.com:videlec/e-antic.git'
 
 $GITHUB_ORG = 'videlec'


### PR DESCRIPTION
We recently simplified the unique-factory that is also used by
exact-real quite a bit. This performs the necessary changes to e-antic
and also speeds up renf_class::operator== which now uses the fact that
renf_class are unique parents so equality can be decided by comparing
poniters.